### PR TITLE
Adjust taskbar badges and add demo reserve hotkey

### DIFF
--- a/Tromby/README.md
+++ b/Tromby/README.md
@@ -1,0 +1,47 @@
+# Tromby
+
+## Présentation
+Tromby est une application overlay Windows 11 toujours au premier plan, conçue en WinUI 3 (.NET 8) pour orchestrer des interactions multimodales avec des modèles de langage (LLM) multi-fournisseurs, des services vocaux hybrides et des actions locales sécurisées. Ce lot livre le socle technique et la structure de solution nécessaires pour poursuivre l’implémentation produit.
+
+## Prérequis
+- Windows 11 22H2 ou supérieur avec Windows App SDK 1.4+.
+- Visual Studio 2022 17.8+ avec charges de travail **.NET Desktop Development** et **Développement avec C++ pour la validation MSIX**.
+- Kit de développement .NET 8 SDK.
+- Accès aux SDK ou API tiers (OpenAI, xAI, Google Gemini, Mistral, Edge TTS) selon les fonctionnalités activées.
+
+## Installation
+1. Cloner le dépôt dans `C:\Dev\trombone`.
+2. Ouvrir `Tromby.sln` dans Visual Studio.
+3. Restaurer les packages NuGet (menu **Build > Restore NuGet Packages** ou `dotnet restore`).
+4. Vérifier que la machine est configurée pour le déploiement WinUI 3 (Windows App SDK installé, certificats de signature MSIX si besoin).
+
+## Configuration
+- Les fichiers de configuration se trouvent sous `config\`.
+- Profils disponibles :
+  - **Prod** : utiliser `config\profiles\prod\appsettings.json` (LLM distants privilégiés, quotas stricts).
+  - **Démo** : utiliser `config\profiles\demo\appsettings.json` (mode dry-run, échantillons de réponses, quotas relâchés).
+  - **Dev** : utiliser `config\profiles\dev\appsettings.json` (journalisation détaillée, bypass de certaines limites).
+- Budgets, personas et politiques sont respectivement définis dans `config\budgets`, `config\persona`, `config\policy`.
+- Les chemins sont consommés par `ConfigurationAdapter` et peuvent être surchargés via variables d’environnement `TROMBY_CONFIG_PATH` et `TROMBY_PROFILE`.
+
+## Build & Lancement
+1. Sélectionner le profil de solution **Release** ou **Debug** selon le besoin.
+2. Cibler l’architecture `x64`.
+3. Lancer `dotnet build` ou l’action **Build Solution** de Visual Studio pour générer les projets WinUI 3 (.NET 8).
+4. Pour le packaging, utiliser le projet d’emballage MSIX (configuration dans Visual Studio : **Publish > Create App Packages**).
+5. Pendant le développement, démarrer `TrombyApp` (F5) : l’overlay s’ouvre en mode CompactOverlay et peut être repositionné.
+
+## Structure du projet
+- `src/TrombyApp` : application WinUI 3, MVVM, services d’orchestration, LLM, sécurité, voix, outils.
+- `config/` : paramètres d’application, budgets, personas, politiques, profils.
+- `tests/Tromby.Tests` : projet de tests unitaires (xUnit) couvrant orchestrateur, scheduler et services clés.
+- `build/` (à créer) : scripts d’emballage MSIX et pipelines CI/CD.
+
+## Dépannage
+- **Erreur de restauration NuGet** : vérifier la connectivité et la version du SDK .NET 8, exécuter `dotnet nuget locals all --clear`.
+- **Échec de lancement WinUI 3** : s’assurer que Windows App SDK Runtime est installé et que le certificat de débogage est approuvé.
+- **Problèmes MSIX** : réinstaller l’application précédente avec `Add-AppxPackage -Remove`, vérifier la signature et réinitialiser le cache déploiement (`wsreset.exe`).
+- **Services LLM indisponibles** : activer le mode Démo ou Éco dans la configuration pour s’appuyer sur les providers locaux.
+
+## Licence
+Licence à définir.

--- a/Tromby/Tromby.sln
+++ b/Tromby/Tromby.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrombyApp", "src\TrombyApp\TrombyApp.csproj", "{19771C6B-4F8C-4889-B9B0-74B8D203E756}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tromby.Tests", "tests\Tromby.Tests\Tromby.Tests.csproj", "{94DF0656-2999-48F3-BB43-DABC2E028433}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{19771C6B-4F8C-4889-B9B0-74B8D203E756}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{19771C6B-4F8C-4889-B9B0-74B8D203E756}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{19771C6B-4F8C-4889-B9B0-74B8D203E756}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{19771C6B-4F8C-4889-B9B0-74B8D203E756}.Release|Any CPU.Build.0 = Release|Any CPU
+{94DF0656-2999-48F3-BB43-DABC2E028433}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{94DF0656-2999-48F3-BB43-DABC2E028433}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{94DF0656-2999-48F3-BB43-DABC2E028433}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{94DF0656-2999-48F3-BB43-DABC2E028433}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/Tromby/config/appsettings.json
+++ b/Tromby/config/appsettings.json
@@ -1,0 +1,31 @@
+{
+  "Profiles": {
+    "Active": "Dev",
+    "Dev": {
+      "Logging": { "Level": "Debug" },
+      "DemoMode": false
+    },
+    "Demo": {
+      "Logging": { "Level": "Information" },
+      "DemoMode": true
+    },
+    "Prod": {
+      "Logging": { "Level": "Warning" },
+      "DemoMode": false
+    }
+  },
+  "Scheduler": {
+    "QualityStart": "00:00:00",
+    "QualityEnd":   "06:00:00",
+    "OverrideMinutes": 30
+  },
+  "Modes": {
+    "DefaultQuality": true
+  },
+  "Tts": {
+    "Preferred": "Edge",
+    "Fallback": "Sapi"
+  },
+  "ConfigPathEnv": "TROMBY_CONFIG_PATH",
+  "ProfileEnv": "TROMBY_PROFILE"
+}

--- a/Tromby/config/budgets.json
+++ b/Tromby/config/budgets.json
@@ -1,0 +1,14 @@
+{
+  "Mode": {
+    "Qualite": {
+      "PerDay": { "Tokens": 100000, "Cost": 10.0 },
+      "PerConversation": { "Tokens": 10000, "Cost": 1.0 },
+      "SoftCapPercent": 80
+    },
+    "Eco": {
+      "PerDay": { "Tokens": 30000, "Cost": 2.0 },
+      "PerConversation": { "Tokens": 3000, "Cost": 0.3 },
+      "SoftCapPercent": 80
+    }
+  }
+}

--- a/Tromby/config/persona.json
+++ b/Tromby/config/persona.json
@@ -1,0 +1,16 @@
+{
+  "Name": "Tromby",
+  "Tagline": "Votre trombone malin, discret et efficace.",
+  "Humor": {
+    "ModeDefault": "drole",
+    "Presets": {
+      "drole":      { "wit": 0.7, "playfulness": 0.6, "sarcasm": 0.1, "emoji": 0.1 },
+      "amical":     { "warmth": 0.8, "reassurance": 0.7, "emoji": 0.15, "wit": 0.3 },
+      "dynamique":  { "energy": 0.8, "brevity": 0.7, "callToAction": 0.6, "wit": 0.4 }
+    },
+    "AdjustByAppMode": {
+      "demo": { "playfulness": 0.1, "warmth": 0.1 },
+      "eco":  { "emoji": -0.1, "wit": -0.1 }
+    }
+  }
+}

--- a/Tromby/config/policy.yaml
+++ b/Tromby/config/policy.yaml
@@ -1,0 +1,42 @@
+limits:
+  api:
+    rps: 2
+    burst: 5
+    concurrent: 3
+    timeoutMs: 30000
+    retries: 3
+    breaker: { failureThreshold: 5, cooldownSec: 30 }
+  localModel:
+    maxCpuPercent: 60
+    maxMemoryMb: 4096
+  sandbox:
+    execTimeoutSec: 15
+    stdoutMaxKb: 1024
+    workingDirQuotaMb: 100
+    forbidChildProcesses: true
+  voice:
+    maxUtteranceSec: 90
+  storage:
+    cacheMaxMb: 1024
+    sessionsMaxMb: 500
+security:
+  allowedCommands:
+    - Get-Process
+    - Get-Service
+    - Get-ChildItem
+    - Get-Content
+    - Set-Content
+    - Test-NetConnection
+    - Get-WmiObject
+    - Get-EventLog
+    - Get-ComputerInfo
+    - Get-Command
+  requireConfirm:
+    - Set-Content
+    - Stop-Process
+    - Remove-Item
+consent:
+  reconsentOnPolicyChange: true
+scheduler:
+  qualityWindow: { start: "00:00", end: "06:00" }
+  overrideMinutes: 30

--- a/Tromby/src/TrombyApp/App.xaml
+++ b/Tromby/src/TrombyApp/App.xaml
@@ -1,0 +1,17 @@
+<Application
+    x:Class="Tromby.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ui="using:Microsoft.UI.Xaml"
+    xmlns:local="using:Tromby">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <ResourceDictionary Source="ms-appx:///UI/Styles/Colors.xaml" />
+                <ResourceDictionary Source="ms-appx:///UI/Styles/Theme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <ui:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/Tromby/src/TrombyApp/App.xaml.cs
+++ b/Tromby/src/TrombyApp/App.xaml.cs
@@ -1,0 +1,101 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml;
+using System;
+using Tromby.Core.Orchestration;
+using Tromby.Core.Persona;
+using Tromby.Core.Scheduling;
+using Tromby.Core.Sessions;
+using Tromby.Infra.Config;
+using Tromby.Infra.Logging;
+using Tromby.Infra.Metrics;
+using Tromby.LLM.Abstractions;
+using Tromby.LLM.Adapters;
+using Tromby.LLM.Router;
+using Tromby.Security;
+using Tromby.Tools.Mcp;
+using Tromby.Tools.Sandbox;
+using Tromby.Voice;
+
+namespace Tromby;
+
+/// <summary>
+/// Application bootstrapper responsible for setting up dependency injection and primary window.
+/// </summary>
+public partial class App : Application
+{
+    private readonly ServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Initializes the application and composes dependencies.
+    /// </summary>
+    public App()
+    {
+        InitializeComponent();
+
+        var services = new ServiceCollection();
+        ConfigureAppConfiguration(services);
+        ConfigureLogging(services);
+        ConfigureServices(services);
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    /// <inheritdoc />
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        var window = _serviceProvider.GetRequiredService<UI.Views.ShellWindow>();
+        window.Activate();
+    }
+
+    private static void ConfigureAppConfiguration(IServiceCollection services)
+    {
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("config/appsettings.json", optional: true)
+            .AddJsonFile("config/budgets.json", optional: false)
+            .AddJsonFile("config/persona.json", optional: false)
+            .AddYamlFile("config/policy.yaml", optional: false);
+
+        services.AddSingleton<IConfiguration>(builder.Build());
+    }
+
+    private static void ConfigureLogging(IServiceCollection services)
+    {
+        services.AddLogging(builder =>
+        {
+            builder.AddDebug();
+            builder.AddProvider(new OverlayLoggerProvider());
+        });
+    }
+
+    private static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSingleton<IConfigurationAdapter, ConfigurationAdapter>();
+        services.AddSingleton<IAppProfileLoader, Infra.Profiles.AppProfileLoader>();
+        services.AddSingleton<IMetricsCollector, MetricsCollector>();
+        services.AddSingleton<LLMProviderRouter>();
+        services.AddSingleton<IConsentService, ConsentService>();
+        services.AddSingleton<ISessionStore, DpapiSessionStore>();
+        services.AddSingleton<IPersonaManager, PersonaManager>();
+        services.AddSingleton<IScheduler, AdaptiveScheduler>();
+        services.AddSingleton<IOverlayOrchestrator, OverlayOrchestrator>();
+        services.AddSingleton<IWhisperService, WhisperService>();
+        services.AddSingleton<IEdgeTtsService, EdgeTtsService>();
+        services.AddSingleton<ISapiFallbackService, SapiFallbackService>();
+        services.AddSingleton<IShellSandbox, PowerShellSandbox>();
+        services.AddSingleton<IMcpClient, McpClient>();
+        services.AddSingleton<Security.PolicyManager>();
+
+        services.AddHttpClient<OpenAiClient>();
+        services.AddTransient<ILLMClient>(sp => sp.GetRequiredService<OpenAiClient>());
+        services.AddSingleton<ILLMClient, MistralClient>();
+        services.AddSingleton<ILLMClient, GeminiClient>();
+        services.AddSingleton<ILLMClient, XaiClient>();
+        services.AddSingleton<ILLMClient, LocalProviderClient>();
+
+        services.AddSingleton<UI.ViewModels.ShellViewModel>();
+        services.AddSingleton<UI.ViewModels.SettingsViewModel>();
+        services.AddSingleton<UI.Views.ShellWindow>();
+    }
+}

--- a/Tromby/src/TrombyApp/Core/Orchestration/IOverlayOrchestrator.cs
+++ b/Tromby/src/TrombyApp/Core/Orchestration/IOverlayOrchestrator.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Core.Orchestration;
+
+/// <summary>
+/// Coordinates overlay interactions, routing requests to the appropriate LLM provider and managing lifecycle.
+/// </summary>
+public interface IOverlayOrchestrator
+{
+    /// <summary>
+    /// Executes an interaction according to the active scheduler and persona.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for the interaction.</param>
+    Task ExecuteAsync(CancellationToken cancellationToken);
+}

--- a/Tromby/src/TrombyApp/Core/Orchestration/OverlayOrchestrator.cs
+++ b/Tromby/src/TrombyApp/Core/Orchestration/OverlayOrchestrator.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Tromby.Core.Persona;
+using Tromby.Core.Scheduling;
+using Tromby.Core.Sessions;
+using Tromby.LLM.Router;
+using Tromby.Tools.Mcp;
+using Tromby.Voice;
+
+namespace Tromby.Core.Orchestration;
+
+/// <summary>
+/// Default orchestrator implementation coordinating audio, MCP actions, and LLM routing.
+/// </summary>
+public sealed class OverlayOrchestrator : IOverlayOrchestrator
+{
+    private readonly LLMProviderRouter _router;
+    private readonly IPersonaManager _personaManager;
+    private readonly IScheduler _scheduler;
+    private readonly ISessionStore _sessionStore;
+    private readonly IMcpClient _mcpClient;
+    private readonly IWhisperService _whisperService;
+    private readonly IEdgeTtsService _edgeTtsService;
+    private readonly ISapiFallbackService _sapiFallback;
+    private readonly ILogger<OverlayOrchestrator> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OverlayOrchestrator"/> class.
+    /// </summary>
+    public OverlayOrchestrator(
+        LLMProviderRouter router,
+        IPersonaManager personaManager,
+        IScheduler scheduler,
+        ISessionStore sessionStore,
+        IMcpClient mcpClient,
+        IWhisperService whisperService,
+        IEdgeTtsService edgeTtsService,
+        ISapiFallbackService sapiFallback,
+        ILogger<OverlayOrchestrator> logger)
+    {
+        _router = router;
+        _personaManager = personaManager;
+        _scheduler = scheduler;
+        _sessionStore = sessionStore;
+        _mcpClient = mcpClient;
+        _whisperService = whisperService;
+        _edgeTtsService = edgeTtsService;
+        _sapiFallback = sapiFallback;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting interaction in {Mode} mode.", _scheduler.ActiveMode);
+        try
+        {
+            var request = await _whisperService.CaptureAsync(cancellationToken).ConfigureAwait(false);
+            var persona = await _personaManager.GetActivePersonaAsync(cancellationToken).ConfigureAwait(false);
+            var llmResponse = await _router.SendAsync(request, persona, cancellationToken).ConfigureAwait(false);
+
+            // TODO: Evaluate MCP action triggers before speaking response.
+            var speechStream = await _edgeTtsService.SpeakAsync(llmResponse, cancellationToken).ConfigureAwait(false);
+            if (speechStream == null)
+            {
+                speechStream = await _sapiFallback.SpeakAsync(llmResponse, cancellationToken).ConfigureAwait(false);
+            }
+
+            await _sessionStore.AppendAsync(llmResponse, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Interaction cancelled.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Interaction failed.");
+            // TODO: notify UI of failure state.
+        }
+    }
+}

--- a/Tromby/src/TrombyApp/Core/Persona/IPersonaManager.cs
+++ b/Tromby/src/TrombyApp/Core/Persona/IPersonaManager.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Core.Persona;
+
+/// <summary>
+/// Provides persona presets and resolves the active Tromby persona.
+/// </summary>
+public interface IPersonaManager
+{
+    /// <summary>
+    /// Gets the available persona presets.
+    /// </summary>
+    IReadOnlyCollection<string> GetPresets();
+
+    /// <summary>
+    /// Resolves the active persona prompt for the current mode.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<string> GetActivePersonaAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sets the persona preset to use.
+    /// </summary>
+    /// <param name="preset">Preset key.</param>
+    void SetPersona(string preset);
+}

--- a/Tromby/src/TrombyApp/Core/Persona/PersonaManager.cs
+++ b/Tromby/src/TrombyApp/Core/Persona/PersonaManager.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Tromby.Infra.Config;
+
+namespace Tromby.Core.Persona;
+
+/// <summary>
+/// Loads persona prompts from configuration and exposes preset switching.
+/// </summary>
+public sealed class PersonaManager : IPersonaManager
+{
+    private readonly IConfiguration _configuration;
+    private readonly IAppProfileLoader _profileLoader;
+    private string _activePreset = "drole";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PersonaManager"/> class.
+    /// </summary>
+    public PersonaManager(IConfiguration configuration, IAppProfileLoader profileLoader)
+    {
+        _configuration = configuration;
+        _profileLoader = profileLoader;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> GetPresets()
+    {
+        var section = _configuration.GetSection("persona:presets");
+        return section.GetChildren().Select(child => child.Key).ToArray();
+    }
+
+    /// <inheritdoc />
+    public Task<string> GetActivePersonaAsync(CancellationToken cancellationToken)
+    {
+        var prompt = _configuration[$"persona:presets:{_activePreset}:prompt"] ?? string.Empty;
+        // TODO: Merge with dynamic profile information and persona mood.
+        return Task.FromResult(prompt);
+    }
+
+    /// <inheritdoc />
+    public void SetPersona(string preset)
+    {
+        _activePreset = preset;
+        _profileLoader.SetActivePersona(preset);
+    }
+}

--- a/Tromby/src/TrombyApp/Core/Scheduling/AdaptiveScheduler.cs
+++ b/Tromby/src/TrombyApp/Core/Scheduling/AdaptiveScheduler.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tromby.Infra.Metrics;
+
+namespace Tromby.Core.Scheduling;
+
+/// <summary>
+/// Scheduler that adapts provider selection based on budgets, metrics, and configured mode.
+/// </summary>
+public sealed class AdaptiveScheduler : IScheduler
+{
+    private readonly IMetricsCollector _metricsCollector;
+    private readonly ILogger<AdaptiveScheduler> _logger;
+    private readonly object _sync = new();
+
+    private SchedulerMode _configuredMode;
+    private TimeSpan _qualityStart;
+    private TimeSpan _qualityEnd;
+    private int _overrideMinutes;
+    private DateTimeOffset? _overrideUntilUtc;
+    private bool? _overrideForceQuality;
+    private bool? _lastEffectiveQuality;
+
+    /// <summary>
+    /// Initializes a new instance of the scheduler.
+    /// </summary>
+    public AdaptiveScheduler(IConfiguration configuration, IMetricsCollector metricsCollector, ILogger<AdaptiveScheduler> logger)
+    {
+        _metricsCollector = metricsCollector;
+        _logger = logger;
+
+        _qualityStart = ParseTime(configuration["scheduler:qualityStart"]) ?? TimeSpan.FromHours(8);
+        _qualityEnd = ParseTime(configuration["scheduler:qualityEnd"]) ?? TimeSpan.FromHours(18);
+        _overrideMinutes = Math.Max(0, configuration.GetValue<int?>("scheduler:overrideMinutes") ?? 15);
+        _configuredMode = ParseMode(configuration["budgets:defaultMode"]);
+    }
+
+    /// <inheritdoc />
+    public string ActiveMode
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return GetModeLabel(_configuredMode);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public TimeSpan QualityStart
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _qualityStart;
+            }
+        }
+        set
+        {
+            lock (_sync)
+            {
+                _qualityStart = NormalizeTime(value);
+                _lastEffectiveQuality = null;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public TimeSpan QualityEnd
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _qualityEnd;
+            }
+        }
+        set
+        {
+            lock (_sync)
+            {
+                _qualityEnd = NormalizeTime(value);
+                _lastEffectiveQuality = null;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public int OverrideMinutes
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _overrideMinutes;
+            }
+        }
+        set
+        {
+            lock (_sync)
+            {
+                _overrideMinutes = Math.Max(0, value);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void ManualOverride(int minutes)
+    {
+        lock (_sync)
+        {
+            if (minutes <= 0)
+            {
+                _overrideUntilUtc = null;
+                _overrideForceQuality = null;
+                _lastEffectiveQuality = null;
+                _logger.LogInformation("Manual override cleared.");
+                return;
+            }
+
+            var baseQuality = DetermineBaseQualityLocked(DateTime.Now);
+            _overrideForceQuality = !baseQuality;
+            _overrideUntilUtc = DateTimeOffset.UtcNow.AddMinutes(minutes);
+            _lastEffectiveQuality = null;
+            _logger.LogInformation(
+                "Manual override set for {Minutes} minutes forcing {Mode}.",
+                minutes,
+                _overrideForceQuality.Value ? "Qualité" : "Éco");
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsInQualityWindow(TimeSpan start, TimeSpan end, DateTime now)
+    {
+        var normalizedStart = NormalizeTime(start);
+        var normalizedEnd = NormalizeTime(end);
+        var time = NormalizeTime(now.TimeOfDay);
+
+        if (normalizedStart == normalizedEnd)
+        {
+            return true;
+        }
+
+        if (normalizedStart < normalizedEnd)
+        {
+            return time >= normalizedStart && time < normalizedEnd;
+        }
+
+        return time >= normalizedStart || time < normalizedEnd;
+    }
+
+    /// <inheritdoc />
+    public bool ComputeEffectiveMode(bool userPrefQuality, TimeSpan start, TimeSpan end, DateTime now)
+    {
+        lock (_sync)
+        {
+            return ComputeEffectiveModeLocked(userPrefQuality, start, end, now);
+        }
+    }
+
+    /// <inheritdoc />
+    public int OverrideMsRemaining()
+    {
+        lock (_sync)
+        {
+            if (_overrideUntilUtc is { } until && _overrideForceQuality.HasValue)
+            {
+                var remaining = until - DateTimeOffset.UtcNow;
+                if (remaining > TimeSpan.Zero)
+                {
+                    return (int)Math.Clamp(remaining.TotalMilliseconds, 0, int.MaxValue);
+                }
+
+                _overrideUntilUtc = null;
+                _overrideForceQuality = null;
+            }
+
+            return 0;
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<string> ResolveTargetTierAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        bool effectiveQuality;
+        bool modeChanged;
+        lock (_sync)
+        {
+            effectiveQuality = ComputeEffectiveModeLocked(_configuredMode != SchedulerMode.Eco, _qualityStart, _qualityEnd, DateTime.Now);
+            modeChanged = _lastEffectiveQuality != effectiveQuality;
+            _lastEffectiveQuality = effectiveQuality;
+        }
+
+        if (modeChanged)
+        {
+            var modeLabel = effectiveQuality ? "Qualité" : "Éco";
+            _metricsCollector.TrackModeSwitch(modeLabel);
+            _logger.LogInformation("Effective scheduler mode switched to {Mode}.", modeLabel);
+        }
+
+        var tier = effectiveQuality ? "premium" : "local";
+        return Task.FromResult(tier);
+    }
+
+    /// <inheritdoc />
+    public void SwitchMode(string mode)
+    {
+        SchedulerMode newMode;
+        bool changed;
+        lock (_sync)
+        {
+            newMode = ParseMode(mode);
+            changed = newMode != _configuredMode;
+            if (changed)
+            {
+                _configuredMode = newMode;
+                _overrideUntilUtc = null;
+                _overrideForceQuality = null;
+                _lastEffectiveQuality = null;
+            }
+        }
+
+        if (changed)
+        {
+            var label = GetModeLabel(newMode);
+            _metricsCollector.TrackModeSwitch(label);
+            _logger.LogInformation("Configured scheduler mode changed to {Mode}.", label);
+        }
+    }
+
+    private bool ComputeEffectiveModeLocked(bool userPrefQuality, TimeSpan start, TimeSpan end, DateTime now)
+    {
+        var baseQuality = DetermineBaseQualityLocked(userPrefQuality, start, end, now);
+        if (_overrideUntilUtc is { } until && _overrideForceQuality.HasValue)
+        {
+            if (until > DateTimeOffset.UtcNow)
+            {
+                return _overrideForceQuality.Value;
+            }
+
+            _overrideUntilUtc = null;
+            _overrideForceQuality = null;
+        }
+
+        return baseQuality;
+    }
+
+    private bool DetermineBaseQualityLocked(DateTime now)
+    {
+        return DetermineBaseQualityLocked(_configuredMode != SchedulerMode.Eco, _qualityStart, _qualityEnd, now);
+    }
+
+    private bool DetermineBaseQualityLocked(bool userPrefQuality, TimeSpan start, TimeSpan end, DateTime now)
+    {
+        var normalizedStart = NormalizeTime(start);
+        var normalizedEnd = NormalizeTime(end);
+
+        return _configuredMode switch
+        {
+            SchedulerMode.Auto => IsInQualityWindow(normalizedStart, normalizedEnd, now),
+            SchedulerMode.Eco => false,
+            SchedulerMode.Quality => true,
+            _ => userPrefQuality
+        };
+    }
+
+    private static TimeSpan NormalizeTime(TimeSpan value)
+    {
+        var totalMinutes = value.TotalMinutes % (24 * 60);
+        if (totalMinutes < 0)
+        {
+            totalMinutes += 24 * 60;
+        }
+
+        return TimeSpan.FromMinutes(totalMinutes);
+    }
+
+    private static SchedulerMode ParseMode(string? mode)
+    {
+        if (string.Equals(mode, "Éco", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, "Eco", StringComparison.OrdinalIgnoreCase))
+        {
+            return SchedulerMode.Eco;
+        }
+
+        if (string.Equals(mode, "Auto", StringComparison.OrdinalIgnoreCase))
+        {
+            return SchedulerMode.Auto;
+        }
+
+        return SchedulerMode.Quality;
+    }
+
+    private static string GetModeLabel(SchedulerMode mode) => mode switch
+    {
+        SchedulerMode.Eco => "Éco",
+        SchedulerMode.Auto => "Auto",
+        _ => "Qualité"
+    };
+
+    private static TimeSpan? ParseTime(string? value)
+    {
+        if (TimeSpan.TryParse(value, out var parsed))
+        {
+            return NormalizeTime(parsed);
+        }
+
+        return null;
+    }
+
+    private enum SchedulerMode
+    {
+        Quality,
+        Eco,
+        Auto
+    }
+}

--- a/Tromby/src/TrombyApp/Core/Scheduling/IScheduler.cs
+++ b/Tromby/src/TrombyApp/Core/Scheduling/IScheduler.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Core.Scheduling;
+
+/// <summary>
+/// Provides scheduling decisions for routing LLM requests based on budgets and system load.
+/// </summary>
+public interface IScheduler
+{
+    /// <summary>
+    /// Gets the current configured mode (Qualité, Éco ou Auto).
+    /// </summary>
+    string ActiveMode { get; }
+
+    /// <summary>
+    /// Gets or sets the daily start of the Qualité window.
+    /// </summary>
+    TimeSpan QualityStart { get; set; }
+
+    /// <summary>
+    /// Gets or sets the daily end of the Qualité window.
+    /// </summary>
+    TimeSpan QualityEnd { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default duration in minutes for manual overrides.
+    /// </summary>
+    int OverrideMinutes { get; set; }
+
+    /// <summary>Définit/retire un override manuel pour la durée demandée (minutes).</summary>
+    void ManualOverride(int minutes);
+
+    /// <summary>Retourne true si la fenêtre Qualité est active (hors override).</summary>
+    bool IsInQualityWindow(TimeSpan start, TimeSpan end, DateTime now);
+
+    /// <summary>Détermine le mode effectif (Qualité= true / Éco= false) selon fenêtre & override.</summary>
+    bool ComputeEffectiveMode(bool userPrefQuality, TimeSpan start, TimeSpan end, DateTime now);
+
+    /// <summary>Millisecondes restantes d’override, 0 si aucun.</summary>
+    int OverrideMsRemaining();
+
+    /// <summary>
+    /// Computes the target provider tier for the next request.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<string> ResolveTargetTierAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Switches the configured mode (Qualité, Éco, Auto).
+    /// </summary>
+    /// <param name="mode">Requested mode.</param>
+    void SwitchMode(string mode);
+}

--- a/Tromby/src/TrombyApp/Core/Sessions/DpapiSessionStore.cs
+++ b/Tromby/src/TrombyApp/Core/Sessions/DpapiSessionStore.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Tromby.Core.Sessions;
+
+/// <summary>
+/// Session store leveraging DPAPI to encrypt persisted conversation history.
+/// </summary>
+public sealed class DpapiSessionStore : ISessionStore
+{
+    private readonly ILogger<DpapiSessionStore> _logger;
+    private readonly string _sessionPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Tromby", "session.bin");
+    private readonly SemaphoreSlim _mutex = new(1, 1);
+    private const int MaxSnapshotBytes = 512 * 1024;
+
+    /// <summary>
+    /// Gets the last restored session snapshot.
+    /// </summary>
+    public string LastSnapshot { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DpapiSessionStore"/> class.
+    /// </summary>
+    public DpapiSessionStore(ILogger<DpapiSessionStore> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task RestoreAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_sessionPath))
+        {
+            LastSnapshot = string.Empty;
+            return;
+        }
+
+        await _mutex.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var payload = await File.ReadAllBytesAsync(_sessionPath, cancellationToken).ConfigureAwait(false);
+            var decrypted = ProtectedData.Unprotect(payload, null, DataProtectionScope.CurrentUser);
+            LastSnapshot = Encoding.UTF8.GetString(decrypted);
+            _logger.LogDebug("Restored session payload of {Length} characters.", LastSnapshot.Length);
+            // TODO: hydrate in-memory conversation state.
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to restore session payload.");
+            LastSnapshot = string.Empty;
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task AppendAsync(string message, CancellationToken cancellationToken)
+    {
+        await _mutex.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Directory.CreateDirectory(Path.GetDirectoryName(_sessionPath)!);
+            if (File.Exists(_sessionPath))
+            {
+                try
+                {
+                    var existingBytes = await File.ReadAllBytesAsync(_sessionPath, cancellationToken).ConfigureAwait(false);
+                    var decrypted = ProtectedData.Unprotect(existingBytes, null, DataProtectionScope.CurrentUser);
+                    LastSnapshot = Encoding.UTF8.GetString(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to load existing session before append.");
+                    LastSnapshot = string.Empty;
+                }
+            }
+
+            var builder = new StringBuilder(LastSnapshot);
+            builder.AppendLine(message);
+            var snapshot = builder.ToString();
+            var utf8Bytes = Encoding.UTF8.GetBytes(snapshot);
+            if (utf8Bytes.Length > MaxSnapshotBytes)
+            {
+                var trimmed = TrimToBudget(utf8Bytes, MaxSnapshotBytes);
+                snapshot = trimmed;
+                utf8Bytes = Encoding.UTF8.GetBytes(snapshot);
+                _logger.LogWarning("Session snapshot truncated to {Limit} bytes to respect storage budget.", MaxSnapshotBytes);
+            }
+
+            LastSnapshot = snapshot;
+            var encrypted = ProtectedData.Protect(utf8Bytes, null, DataProtectionScope.CurrentUser);
+            await File.WriteAllBytesAsync(_sessionPath, encrypted, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to persist session snapshot.");
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    private static string TrimToBudget(byte[] source, int limit)
+    {
+        if (source.Length <= limit)
+        {
+            return Encoding.UTF8.GetString(source);
+        }
+
+        var start = source.Length - limit;
+        return Encoding.UTF8.GetString(source, start, limit);
+    }
+}

--- a/Tromby/src/TrombyApp/Core/Sessions/ISessionStore.cs
+++ b/Tromby/src/TrombyApp/Core/Sessions/ISessionStore.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Core.Sessions;
+
+/// <summary>
+/// Provides persistence for encrypted conversation sessions.
+/// </summary>
+public interface ISessionStore
+{
+    /// <summary>
+    /// Restores the last session into memory.
+    /// </summary>
+    Task RestoreAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Appends a new entry to the current session and persists it.
+    /// </summary>
+    /// <param name="message">Content to append.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task AppendAsync(string message, CancellationToken cancellationToken);
+}

--- a/Tromby/src/TrombyApp/Infra/BudgetService.cs
+++ b/Tromby/src/TrombyApp/Infra/BudgetService.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Tromby.Infra;
+
+/// <summary>
+/// Represents supported quality modes for budget tracking.
+/// </summary>
+public enum QualityMode
+{
+    /// <summary>
+    /// Premium quality mode using remote providers.
+    /// </summary>
+    Qualite,
+
+    /// <summary>
+    /// Eco mode prioritising local execution.
+    /// </summary>
+    Eco
+}
+
+/// <summary>
+/// Strongly typed representation of budgets.json configuration.
+/// </summary>
+public sealed class BudgetConfig
+{
+    public required ModeConfig Mode { get; init; }
+
+    public sealed class ModeConfig
+    {
+        public required Limits Qualite { get; init; }
+        public required Limits Eco { get; init; }
+    }
+
+    public sealed class Limits
+    {
+        public required Cap PerDay { get; init; }
+        public required Cap PerConversation { get; init; }
+        public int SoftCapPercent { get; init; } = 80;
+    }
+
+    public sealed class Cap
+    {
+        public int Tokens { get; init; }
+        public decimal Cost { get; init; }
+    }
+}
+
+/// <summary>
+/// Immutable snapshot returned to UI displaying usage and remaining capacity.
+/// </summary>
+public sealed class BudgetSnapshot
+{
+    public int DayTokensUsed { get; init; }
+    public decimal DayCostUsed { get; init; }
+    public int DayTokensCap { get; init; }
+    public decimal DayCostCap { get; init; }
+    public int ConversationTokensUsed { get; init; }
+    public decimal ConversationCostUsed { get; init; }
+    public int ConversationTokensCap { get; init; }
+    public decimal ConversationCostCap { get; init; }
+    public int SoftCapPercent { get; init; }
+
+    public int DayPercent => DayTokensCap > 0 ? (int)Math.Clamp(Math.Round((double)DayTokensUsed / DayTokensCap * 100, MidpointRounding.AwayFromZero), 0, 100) : 0;
+    public int ConversationPercent => ConversationTokensCap > 0 ? (int)Math.Clamp(Math.Round((double)ConversationTokensUsed / ConversationTokensCap * 100, MidpointRounding.AwayFromZero), 0, 100) : 0;
+
+    public bool SoftCapReached => SoftCapPercent > 0 && (DayPercent >= SoftCapPercent || ConversationPercent >= SoftCapPercent);
+
+    public bool IsHardCapReached =>
+        DayTokensUsed >= DayTokensCap ||
+        DayCostUsed >= DayCostCap ||
+        ConversationTokensUsed >= ConversationTokensCap ||
+        ConversationCostUsed >= ConversationCostCap;
+}
+
+/// <summary>
+/// Central budget tracker enforcing per-day and per-conversation limits with soft/hard caps.
+/// </summary>
+public sealed class BudgetService
+{
+    private sealed class Usage
+    {
+        public int Tokens;
+        public decimal Cost;
+    }
+
+    private readonly BudgetConfig _config;
+    private readonly object _sync = new();
+    private readonly Dictionary<Guid, Usage> _conversations = new();
+    private DateTime _currentDayUtc = DateTime.UtcNow.Date;
+    private Usage _daily = new();
+
+    public BudgetService(string budgetsJsonPath)
+    {
+        if (string.IsNullOrWhiteSpace(budgetsJsonPath))
+        {
+            throw new ArgumentException("Budget path required", nameof(budgetsJsonPath));
+        }
+
+        if (!File.Exists(budgetsJsonPath))
+        {
+            throw new FileNotFoundException("Budget configuration not found.", budgetsJsonPath);
+        }
+
+        var json = File.ReadAllText(budgetsJsonPath);
+        var config = JsonSerializer.Deserialize<BudgetConfig>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        _config = config ?? throw new InvalidOperationException("Invalid budgets.json format.");
+    }
+
+    /// <summary>
+    /// Begins tracking for a conversation scope and returns its identifier.
+    /// </summary>
+    public Guid BeginConversation()
+    {
+        lock (_sync)
+        {
+            EnsureDayLocked(DateTime.UtcNow);
+            var id = Guid.NewGuid();
+            _conversations[id] = new Usage();
+            return id;
+        }
+    }
+
+    /// <summary>
+    /// Releases all tracking data for a conversation.
+    /// </summary>
+    public void EndConversation(Guid conversationId)
+    {
+        lock (_sync)
+        {
+            _conversations.Remove(conversationId);
+        }
+    }
+
+    /// <summary>
+    /// Attempts to reserve tokens/cost; returns false when a hard cap would be exceeded.
+    /// </summary>
+    public bool TryConsume(QualityMode mode, Guid conversationId, int tokens, decimal cost, out BudgetSnapshot snapshot, out bool softCapTriggered)
+    {
+        lock (_sync)
+        {
+            EnsureDayLocked(DateTime.UtcNow);
+            var limits = GetLimits(mode);
+
+            if (!_conversations.TryGetValue(conversationId, out var conversation))
+            {
+                conversation = new Usage();
+                _conversations[conversationId] = conversation;
+            }
+
+            var nextDailyTokens = checked(_daily.Tokens + tokens);
+            var nextDailyCost = _daily.Cost + cost;
+            var nextConversationTokens = conversation.Tokens + tokens;
+            var nextConversationCost = conversation.Cost + cost;
+
+            snapshot = new BudgetSnapshot
+            {
+                DayTokensUsed = nextDailyTokens,
+                DayCostUsed = nextDailyCost,
+                DayTokensCap = limits.PerDay.Tokens,
+                DayCostCap = limits.PerDay.Cost,
+                ConversationTokensUsed = nextConversationTokens,
+                ConversationCostUsed = nextConversationCost,
+                ConversationTokensCap = limits.PerConversation.Tokens,
+                ConversationCostCap = limits.PerConversation.Cost,
+                SoftCapPercent = limits.SoftCapPercent
+            };
+
+            softCapTriggered = snapshot.SoftCapReached;
+            if (snapshot.IsHardCapReached)
+            {
+                return false;
+            }
+
+            _daily.Tokens = nextDailyTokens;
+            _daily.Cost = nextDailyCost;
+            conversation.Tokens = nextConversationTokens;
+            conversation.Cost = nextConversationCost;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Refunds usage when a completion is discarded or retried.
+    /// </summary>
+    public void Refund(Guid conversationId, int tokens, decimal cost)
+    {
+        lock (_sync)
+        {
+            EnsureDayLocked(DateTime.UtcNow);
+            _daily.Tokens = Math.Max(0, _daily.Tokens - tokens);
+            _daily.Cost = Math.Max(0m, _daily.Cost - cost);
+
+            if (_conversations.TryGetValue(conversationId, out var usage))
+            {
+                usage.Tokens = Math.Max(0, usage.Tokens - tokens);
+                usage.Cost = Math.Max(0m, usage.Cost - cost);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the latest snapshot for UI display.
+    /// </summary>
+    public BudgetSnapshot GetSnapshot(QualityMode mode, Guid? conversationId = null)
+    {
+        lock (_sync)
+        {
+            EnsureDayLocked(DateTime.UtcNow);
+            var limits = GetLimits(mode);
+            Usage conversation = new();
+            if (conversationId.HasValue && _conversations.TryGetValue(conversationId.Value, out var scoped))
+            {
+                conversation = scoped;
+            }
+
+            return new BudgetSnapshot
+            {
+                DayTokensUsed = _daily.Tokens,
+                DayCostUsed = _daily.Cost,
+                DayTokensCap = limits.PerDay.Tokens,
+                DayCostCap = limits.PerDay.Cost,
+                ConversationTokensUsed = conversation.Tokens,
+                ConversationCostUsed = conversation.Cost,
+                ConversationTokensCap = limits.PerConversation.Tokens,
+                ConversationCostCap = limits.PerConversation.Cost,
+                SoftCapPercent = limits.SoftCapPercent
+            };
+        }
+    }
+
+    private BudgetConfig.Limits GetLimits(QualityMode mode) =>
+        mode == QualityMode.Qualite ? _config.Mode.Qualite : _config.Mode.Eco;
+
+    private void EnsureDayLocked(DateTime now)
+    {
+        if (now.Date == _currentDayUtc)
+        {
+            return;
+        }
+
+        _currentDayUtc = now.Date;
+        _daily = new Usage();
+        _conversations.Clear();
+    }
+}

--- a/Tromby/src/TrombyApp/Infra/Config/ConfigurationAdapter.cs
+++ b/Tromby/src/TrombyApp/Infra/Config/ConfigurationAdapter.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace Tromby.Infra.Config;
+
+/// <summary>
+/// Default configuration adapter using <see cref="IConfiguration"/>.
+/// </summary>
+public sealed class ConfigurationAdapter : IConfigurationAdapter
+{
+    private readonly IConfiguration _configuration;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationAdapter"/> class.
+    /// </summary>
+    public ConfigurationAdapter(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetCacheTtl()
+    {
+        var ttlSeconds = _configuration.GetValue("budgets:cacheTtlSeconds", 60);
+        return TimeSpan.FromSeconds(ttlSeconds);
+    }
+}

--- a/Tromby/src/TrombyApp/Infra/Config/IAppProfileLoader.cs
+++ b/Tromby/src/TrombyApp/Infra/Config/IAppProfileLoader.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Infra.Config;
+
+/// <summary>
+/// Manages persisted application profile data (persona, schedules, preferences).
+/// </summary>
+public interface IAppProfileLoader
+{
+    /// <summary>
+    /// Loads the persisted profile.
+    /// </summary>
+    Task LoadAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sets the active persona preset for persistence.
+    /// </summary>
+    void SetActivePersona(string preset);
+}

--- a/Tromby/src/TrombyApp/Infra/Config/IConfigurationAdapter.cs
+++ b/Tromby/src/TrombyApp/Infra/Config/IConfigurationAdapter.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Tromby.Infra.Config;
+
+/// <summary>
+/// Provides strongly typed accessors for configuration values.
+/// </summary>
+public interface IConfigurationAdapter
+{
+    /// <summary>
+    /// Gets the cache TTL for offline-first interactions.
+    /// </summary>
+    TimeSpan GetCacheTtl();
+}

--- a/Tromby/src/TrombyApp/Infra/Config/YamlConfigurationExtensions.cs
+++ b/Tromby/src/TrombyApp/Infra/Config/YamlConfigurationExtensions.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using YamlDotNet.Serialization;
+
+namespace Tromby.Infra.Config;
+
+/// <summary>
+/// Provides YAML configuration loading via YamlDotNet.
+/// </summary>
+public static class YamlConfigurationExtensions
+{
+    /// <summary>
+    /// Adds a YAML configuration file to the builder.
+    /// </summary>
+    public static IConfigurationBuilder AddYamlFile(this IConfigurationBuilder builder, string path, bool optional)
+    {
+        var fullPath = Path.Combine(AppContext.BaseDirectory, path);
+        if (!File.Exists(fullPath))
+        {
+            if (!optional)
+            {
+                throw new FileNotFoundException($"Configuration file '{path}' not found.");
+            }
+
+            return builder;
+        }
+
+        var deserializer = new DeserializerBuilder().Build();
+        var serializer = new SerializerBuilder().JsonCompatible().Build();
+        using var reader = File.OpenText(fullPath);
+        var yamlObject = deserializer.Deserialize(reader);
+        var json = serializer.Serialize(yamlObject);
+        builder.AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(json)));
+        return builder;
+    }
+}

--- a/Tromby/src/TrombyApp/Infra/Logging/OverlayLoggerProvider.cs
+++ b/Tromby/src/TrombyApp/Infra/Logging/OverlayLoggerProvider.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Tromby.Infra.Logging;
+
+/// <summary>
+/// Minimal structured logger provider capturing overlay events for diagnostics.
+/// </summary>
+public sealed class OverlayLoggerProvider : ILoggerProvider
+{
+    private readonly ConcurrentDictionary<string, OverlayLogger> _loggers = new();
+
+    /// <inheritdoc />
+    public ILogger CreateLogger(string categoryName)
+    {
+        return _loggers.GetOrAdd(categoryName, name => new OverlayLogger(name));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _loggers.Clear();
+    }
+
+    private sealed class OverlayLogger : ILogger
+    {
+        private readonly string _categoryName;
+
+        public OverlayLogger(string categoryName)
+        {
+            _categoryName = categoryName;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var message = formatter(state, exception);
+            // TODO: Persist logs to rolling buffer exposed in diagnostics panel.
+            System.Diagnostics.Debug.WriteLine($"[{logLevel}] {_categoryName}: {message}");
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/Tromby/src/TrombyApp/Infra/Metrics/IMetricsCollector.cs
+++ b/Tromby/src/TrombyApp/Infra/Metrics/IMetricsCollector.cs
@@ -1,0 +1,47 @@
+namespace Tromby.Infra.Metrics;
+
+/// <summary>
+/// Collects telemetry for latency, mode changes, throttling, and resource usage.
+/// </summary>
+public interface IMetricsCollector
+{
+    /// <summary>
+    /// Records completion for a provider.
+    /// </summary>
+    void TrackCompletion(string providerName);
+
+    /// <summary>
+    /// Records a mode switch event.
+    /// </summary>
+    void TrackModeSwitch(string mode);
+
+    /// <summary>
+    /// Records consumption of a budget.
+    /// </summary>
+    /// <param name="mode">Quality mode used for the operation.</param>
+    /// <param name="tokens">Tokens consumed.</param>
+    /// <param name="cost">Estimated euro cost.</param>
+    /// <param name="percent">Percent of daily budget consumed.</param>
+    /// <param name="softCap">Indicates whether the soft cap has been reached.</param>
+    /// <param name="hardCap">Indicates whether the hard cap has been reached.</param>
+    void TrackBudgetUsed(string mode, int tokens, decimal cost, int percent, bool softCap, bool hardCap);
+
+    /// <summary>
+    /// Records a throttling event.
+    /// </summary>
+    /// <param name="scope">Scope affected by throttling.</param>
+    /// <param name="reason">Reason of the throttling.</param>
+    void TrackThrottle(string scope, string reason);
+
+    /// <summary>
+    /// Records a tool invocation.
+    /// </summary>
+    /// <param name="toolName">Name of the tool invoked.</param>
+    void TrackToolInvocation(string toolName);
+
+    /// <summary>
+    /// Records cancellation of a tool invocation.
+    /// </summary>
+    /// <param name="toolName">Name of the tool cancelled.</param>
+    void TrackToolCancelled(string toolName);
+}

--- a/Tromby/src/TrombyApp/Infra/Metrics/MetricsCollector.cs
+++ b/Tromby/src/TrombyApp/Infra/Metrics/MetricsCollector.cs
@@ -1,0 +1,65 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Tromby.Infra.Metrics;
+
+/// <summary>
+/// In-memory metrics collector with TODO hooks for exporting to Application Insights.
+/// </summary>
+public sealed class MetricsCollector : IMetricsCollector
+{
+    private readonly ILogger<MetricsCollector> _logger;
+    private readonly ConcurrentDictionary<string, int> _completionCounters = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MetricsCollector"/> class.
+    /// </summary>
+    public MetricsCollector(ILogger<MetricsCollector> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public void TrackCompletion(string providerName)
+    {
+        _completionCounters.AddOrUpdate(providerName, 1, (_, current) => current + 1);
+        _logger.LogDebug("Completion tracked for {Provider}.", providerName);
+    }
+
+    /// <inheritdoc />
+    public void TrackModeSwitch(string mode)
+    {
+        _logger.LogInformation("Mode switched to {Mode}.", mode);
+    }
+
+    /// <inheritdoc />
+    public void TrackBudgetUsed(string mode, int tokens, decimal cost, int percent, bool softCap, bool hardCap)
+    {
+        _logger.LogInformation(
+            "Budget used in mode {Mode}: tokens={Tokens} cost={Cost} percent={Percent} softCap={SoftCap} hardCap={HardCap}.",
+            mode,
+            tokens,
+            cost,
+            percent,
+            softCap,
+            hardCap);
+    }
+
+    /// <inheritdoc />
+    public void TrackThrottle(string scope, string reason)
+    {
+        _logger.LogWarning("Throttle triggered for {Scope}: {Reason}.", scope, reason);
+    }
+
+    /// <inheritdoc />
+    public void TrackToolInvocation(string toolName)
+    {
+        _logger.LogDebug("Tool invoked: {Tool}.", toolName);
+    }
+
+    /// <inheritdoc />
+    public void TrackToolCancelled(string toolName)
+    {
+        _logger.LogWarning("Tool cancelled: {Tool}.", toolName);
+    }
+}

--- a/Tromby/src/TrombyApp/Infra/Profiles/AppProfileLoader.cs
+++ b/Tromby/src/TrombyApp/Infra/Profiles/AppProfileLoader.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Tromby.Infra.Config;
+
+namespace Tromby.Infra.Profiles;
+
+/// <summary>
+/// Loads and persists simple JSON profile data.
+/// </summary>
+public sealed class AppProfileLoader : IAppProfileLoader
+{
+    private readonly ILogger<AppProfileLoader> _logger;
+    private readonly string _profilePath = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "Tromby", "profile.json");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AppProfileLoader"/> class.
+    /// </summary>
+    public AppProfileLoader(ILogger<AppProfileLoader> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task LoadAsync(CancellationToken cancellationToken)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!File.Exists(_profilePath))
+            {
+                return;
+            }
+
+            var payload = File.ReadAllText(_profilePath);
+            _logger.LogDebug("Loaded profile: {Payload}", payload);
+            // TODO: Deserialize into strongly typed profile.
+        }, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public void SetActivePersona(string preset)
+    {
+        var json = JsonSerializer.Serialize(new { persona = preset });
+        Directory.CreateDirectory(Path.GetDirectoryName(_profilePath)!);
+        File.WriteAllText(_profilePath, json);
+    }
+}

--- a/Tromby/src/TrombyApp/Infra/RateLimits.cs
+++ b/Tromby/src/TrombyApp/Infra/RateLimits.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Threading;
+using System.Threading.RateLimiting;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Tromby.Infra;
+
+/// <summary>
+/// Centralized rate limiting and concurrency guard for outbound operations.
+/// </summary>
+public sealed class RateLimits : IDisposable
+{
+    private readonly FixedWindowRateLimiter _requestLimiter;
+    private readonly SemaphoreSlim _concurrencyLimiter;
+    private readonly ILogger<RateLimits> _logger;
+    private readonly TimeSpan _window;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimits"/> class.
+    /// </summary>
+    /// <param name="requestsPerMinute">Allowed requests per minute.</param>
+    /// <param name="concurrencyLimit">Maximum concurrent operations.</param>
+    /// <param name="logger">Logger instance.</param>
+    public RateLimits(int requestsPerMinute, int concurrencyLimit, ILogger<RateLimits> logger)
+    {
+        if (requestsPerMinute <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(requestsPerMinute));
+        }
+
+        if (concurrencyLimit <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(concurrencyLimit));
+        }
+
+        _window = TimeSpan.FromMinutes(1);
+        _requestLimiter = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = requestsPerMinute,
+            Window = _window,
+            AutoReplenishment = true,
+            QueueLimit = requestsPerMinute,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+        });
+        _concurrencyLimiter = new SemaphoreSlim(concurrencyLimit, concurrencyLimit);
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Executes a work item within the configured rate and concurrency limits.
+    /// </summary>
+    public async Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> work, CancellationToken cancellationToken)
+    {
+        await _concurrencyLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
+        RateLimitLease? lease = null;
+        try
+        {
+            lease = await AcquireRequestAsync(cancellationToken).ConfigureAwait(false);
+            return await work(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            lease?.Dispose();
+            _concurrencyLimiter.Release();
+        }
+    }
+
+    /// <summary>
+    /// Executes a work item without returning a value within the configured rate limits.
+    /// </summary>
+    public async Task ExecuteAsync(Func<CancellationToken, Task> work, CancellationToken cancellationToken)
+    {
+        await _concurrencyLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
+        RateLimitLease? lease = null;
+        try
+        {
+            lease = await AcquireRequestAsync(cancellationToken).ConfigureAwait(false);
+            await work(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            lease?.Dispose();
+            _concurrencyLimiter.Release();
+        }
+    }
+
+    /// <summary>
+    /// Acquires a concurrency slot returning an <see cref="IDisposable"/> that releases on dispose.
+    /// </summary>
+    public async Task<IDisposable> AcquireConcurrencyAsync(CancellationToken cancellationToken)
+    {
+        await _concurrencyLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new Releaser(_concurrencyLimiter);
+    }
+
+    private async Task<RateLimitLease> AcquireRequestAsync(CancellationToken cancellationToken)
+    {
+        var lease = await _requestLimiter.AcquireAsync(1, cancellationToken).ConfigureAwait(false);
+        if (lease.IsAcquired)
+        {
+            return lease;
+        }
+
+        lease.Dispose();
+        _logger.LogWarning("Rate limit exceeded for window of {Window}.", _window);
+        throw new RateLimitExceededException("Request rate limit reached.");
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _requestLimiter.Dispose();
+        _concurrencyLimiter.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class Releaser : IDisposable
+    {
+        private readonly SemaphoreSlim _semaphore;
+        private bool _released;
+
+        public Releaser(SemaphoreSlim semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        public void Dispose()
+        {
+            if (_released)
+            {
+                return;
+            }
+
+            _released = true;
+            _semaphore.Release();
+        }
+    }
+}
+
+/// <summary>
+/// Exception thrown when a rate limit prevents execution.
+/// </summary>
+public sealed class RateLimitExceededException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RateLimitExceededException"/> class.
+    /// </summary>
+    public RateLimitExceededException(string message)
+        : base(message)
+    {
+    }
+}

--- a/Tromby/src/TrombyApp/Infra/TaskbarBadgeService.cs
+++ b/Tromby/src/TrombyApp/Infra/TaskbarBadgeService.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Drawing.Text;
+using System.Runtime.InteropServices;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+
+namespace Tromby.Infra;
+
+/// <summary>
+/// Manages taskbar progress and overlay icons for the Tromby overlay window.
+/// </summary>
+public sealed class TaskbarBadgeService : IDisposable
+{
+    private readonly nint _hwnd;
+    private readonly ITaskbarList3 _taskbar;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskbarBadgeService"/> class.
+    /// </summary>
+    /// <param name="hwnd">Window handle owning the taskbar button.</param>
+    public TaskbarBadgeService(nint hwnd)
+    {
+        _hwnd = hwnd;
+        _taskbar = (ITaskbarList3)new CTaskbarList();
+        _taskbar.HrInit();
+    }
+
+    /// <summary>
+    /// Updates taskbar progress and overlay icon based on the provided mode and budget percentage.
+    /// </summary>
+    /// <param name="mode">Current quality mode.</param>
+    /// <param name="percent">Budget usage percentage.</param>
+    public void Update(QualityMode mode, int percent)
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(TaskbarBadgeService));
+        }
+
+        percent = Math.Clamp(percent, 0, 100);
+
+        var flag = TBPFLAG.TBPF_NORMAL;
+        if (percent >= 95)
+        {
+            flag = TBPFLAG.TBPF_ERROR;
+        }
+        else if (percent >= 80)
+        {
+            flag = TBPFLAG.TBPF_PAUSED;
+        }
+
+        _taskbar.SetProgressState(_hwnd, flag);
+        _taskbar.SetProgressValue(_hwnd, (ulong)percent, 100);
+
+        var overlay = CreateLetterIcon(mode == QualityMode.Qualite ? 'Q' : 'E');
+        try
+        {
+            _taskbar.SetOverlayIcon(_hwnd, overlay, mode == QualityMode.Qualite ? "Qualité" : "Éco");
+        }
+        finally
+        {
+            if (overlay != 0)
+            {
+                PInvoke.DestroyIcon(new HICON(overlay));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clears taskbar progress and overlay icon.
+    /// </summary>
+    public void Clear()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _taskbar.SetProgressState(_hwnd, TBPFLAG.TBPF_NOPROGRESS);
+        _taskbar.SetOverlayIcon(_hwnd, 0, null);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        Clear();
+        Marshal.FinalReleaseComObject(_taskbar);
+        _disposed = true;
+        GC.SuppressFinalize(this);
+    }
+
+    private static nint CreateLetterIcon(char letter)
+    {
+        try
+        {
+            using var bitmap = new Bitmap(32, 32, PixelFormat.Format32bppArgb);
+            using var graphics = Graphics.FromImage(bitmap);
+            graphics.Clear(Color.Transparent);
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+            graphics.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
+
+            using var brush = new SolidBrush(letter == 'Q' ? Color.FromArgb(0, 120, 215) : Color.FromArgb(0, 153, 51));
+            using var format = new StringFormat
+            {
+                Alignment = StringAlignment.Center,
+                LineAlignment = StringAlignment.Center
+            };
+
+            using var font = new Font("Segoe UI", 20, FontStyle.Bold, GraphicsUnit.Pixel);
+            graphics.DrawString(letter.ToString(), font, brush, new RectangleF(0, 0, 32, 32), format);
+
+            var iconHandle = bitmap.GetHicon();
+            return iconHandle;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    [ComImport]
+    [Guid("56FDF344-FD6D-11d0-958A-006097C9A090")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface ITaskbarList
+    {
+        void HrInit();
+        void AddTab(nint hwnd);
+        void DeleteTab(nint hwnd);
+        void ActivateTab(nint hwnd);
+        void SetActiveAlt(nint hwnd);
+    }
+
+    [ComImport]
+    [Guid("602D4995-B13A-429b-A66E-1935E44F4317")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface ITaskbarList2 : ITaskbarList
+    {
+        new void HrInit();
+        new void AddTab(nint hwnd);
+        new void DeleteTab(nint hwnd);
+        new void ActivateTab(nint hwnd);
+        new void SetActiveAlt(nint hwnd);
+        void MarkFullscreenWindow(nint hwnd, [MarshalAs(UnmanagedType.Bool)] bool fFullscreen);
+    }
+
+    [ComImport]
+    [Guid("EA1AFB91-9E28-4B86-90E9-9E9F8A5EEA84")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface ITaskbarList3 : ITaskbarList2
+    {
+        new void HrInit();
+        new void AddTab(nint hwnd);
+        new void DeleteTab(nint hwnd);
+        new void ActivateTab(nint hwnd);
+        new void SetActiveAlt(nint hwnd);
+        new void MarkFullscreenWindow(nint hwnd, bool fFullscreen);
+        void SetProgressValue(nint hwnd, ulong ullCompleted, ulong ullTotal);
+        void SetProgressState(nint hwnd, TBPFLAG tbpFlags);
+        void RegisterTab(nint hwndTab, nint hwndMDI);
+        void UnregisterTab(nint hwndTab);
+        void SetTabOrder(nint hwndTab, nint hwndInsertBefore);
+        void SetTabActive(nint hwndTab, nint hwndMDI, uint dwReserved);
+        void ThumbBarAddButtons(nint hwnd, uint cButtons, nint pButtons);
+        void ThumbBarUpdateButtons(nint hwnd, uint cButtons, nint pButtons);
+        void ThumbBarSetImageList(nint hwnd, nint himl);
+        void SetOverlayIcon(nint hwnd, nint hIcon, [MarshalAs(UnmanagedType.LPWStr)] string? pszDescription);
+        void SetThumbnailTooltip(nint hwnd, [MarshalAs(UnmanagedType.LPWStr)] string pszTip);
+        void SetThumbnailClip(nint hwnd, nint prcClip);
+    }
+
+    [ComImport]
+    [Guid("56FDF344-FD6D-11d0-958A-006097C9A090")]
+    private sealed class CTaskbarList
+    {
+    }
+
+    private enum TBPFLAG
+    {
+        TBPF_NOPROGRESS = 0,
+        TBPF_INDETERMINATE = 0x1,
+        TBPF_NORMAL = 0x2,
+        TBPF_ERROR = 0x4,
+        TBPF_PAUSED = 0x8
+    }
+}

--- a/Tromby/src/TrombyApp/LLM/Abstractions/ILLMClient.cs
+++ b/Tromby/src/TrombyApp/LLM/Abstractions/ILLMClient.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.LLM.Abstractions;
+
+/// <summary>
+/// Provides a unified contract for interacting with LLM providers, including streaming and cost estimation helpers.
+/// </summary>
+public interface ILLMClient
+{
+    /// <summary>
+    /// Gets the logical provider name (OpenAI, Mistral, Local, etc.).
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Sends a prompt to the provider and returns the aggregated completion.
+    /// </summary>
+    /// <param name="prompt">Prompt payload.</param>
+    /// <param name="persona">Persona instructions sent as a system message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<string> CompleteAsync(string prompt, string persona, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Streams a completion response chunk-by-chunk.
+    /// </summary>
+    /// <param name="prompt">Prompt payload.</param>
+    /// <param name="persona">Persona instructions.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<IAsyncEnumerable<string>> StreamAsync(string prompt, string persona, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Estimates token usage for budgeting purposes.
+    /// </summary>
+    /// <param name="text">Text payload to evaluate.</param>
+    int EstimateTokens(string text);
+}

--- a/Tromby/src/TrombyApp/LLM/Adapters/GeminiClient.cs
+++ b/Tromby/src/TrombyApp/LLM/Adapters/GeminiClient.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tromby.LLM.Abstractions;
+
+namespace Tromby.LLM.Adapters;
+
+/// <summary>
+/// Adapter for Google Gemini APIs.
+/// </summary>
+public sealed class GeminiClient : ILLMClient
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<GeminiClient> _logger;
+    private readonly string _endpoint;
+    private readonly string? _apiKey;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeminiClient"/> class.
+    /// </summary>
+    public GeminiClient(IHttpClientFactory httpClientFactory, IConfiguration configuration, ILogger<GeminiClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+
+        var section = configuration.GetSection("llm:gemini");
+        var model = section["model"] ?? "gemini-pro";
+        var baseEndpoint = section["endpoint"] ?? "https://generativelanguage.googleapis.com/v1beta";
+        _endpoint = $"{baseEndpoint.TrimEnd('/')}/models/{model}:generateContent";
+        _apiKey = section["apiKey"];
+    }
+
+    /// <inheritdoc />
+    public string Name => "gemini";
+
+    /// <inheritdoc />
+    public async Task<string> CompleteAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_apiKey))
+        {
+            _logger.LogWarning("Gemini API key missing, returning simulated completion.");
+            return $"[Gemini simulé] {prompt}";
+        }
+
+        var client = _httpClientFactory.CreateClient(nameof(GeminiClient));
+        var body = new
+        {
+            contents = new[]
+            {
+                new
+                {
+                    parts = new[]
+                    {
+                        new { text = persona },
+                        new { text = prompt }
+                    }
+                }
+            }
+        };
+
+        var requestUri = new UriBuilder(_endpoint) { Query = $"key={_apiKey}" }.Uri;
+        using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+        {
+            Content = JsonContent.Create(body, options: SerializerOptions)
+        };
+
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException($"Gemini completion failed: {response.StatusCode} - {error}");
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<GeminiResponse>(SerializerOptions, cancellationToken).ConfigureAwait(false);
+        var completion = payload?.Candidates?
+            .SelectMany(candidate => candidate.Content?.Parts ?? Array.Empty<GeminiPart>())
+            .Select(part => part.Text)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Aggregate(string.Empty, (acc, next) => string.Concat(acc, next)) ?? string.Empty;
+
+        return completion;
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncEnumerable<string>> StreamAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        var completion = await CompleteAsync(prompt, persona, cancellationToken).ConfigureAwait(false);
+        return CreateSingleChunk(completion);
+    }
+
+    /// <inheritdoc />
+    public int EstimateTokens(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        return Math.Max(1, text.Length / 4);
+    }
+
+    private static Task<IAsyncEnumerable<string>> CreateSingleChunk(string content)
+    {
+        async IAsyncEnumerable<string> Enumerate()
+        {
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                yield return content;
+            }
+
+            await Task.CompletedTask;
+        }
+
+        return Task.FromResult<IAsyncEnumerable<string>>(Enumerate());
+    }
+
+    private sealed record GeminiResponse(
+        [property: JsonPropertyName("candidates")] IReadOnlyList<GeminiCandidate>? Candidates);
+
+    private sealed record GeminiCandidate(
+        [property: JsonPropertyName("content")] GeminiContent? Content);
+
+    private sealed record GeminiContent(
+        [property: JsonPropertyName("parts")] IReadOnlyList<GeminiPart>? Parts);
+
+    private sealed record GeminiPart(
+        [property: JsonPropertyName("text")] string? Text);
+}

--- a/Tromby/src/TrombyApp/LLM/Adapters/LocalProviderClient.cs
+++ b/Tromby/src/TrombyApp/LLM/Adapters/LocalProviderClient.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tromby.LLM.Abstractions;
+
+namespace Tromby.LLM.Adapters;
+
+/// <summary>
+/// Adapter for local inference engines (GGUF, ONNX, etc.).
+/// </summary>
+public sealed class LocalProviderClient : ILLMClient
+{
+    private readonly ILogger<LocalProviderClient> _logger;
+    private readonly string? _command;
+    private readonly string? _arguments;
+    private readonly string? _workingDirectory;
+    private readonly string _inputTemplate;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalProviderClient"/> class.
+    /// </summary>
+    public LocalProviderClient(IConfiguration configuration, ILogger<LocalProviderClient> logger)
+    {
+        _logger = logger;
+        var section = configuration.GetSection("llm:local");
+        _command = section["command"];
+        _arguments = section["arguments"];
+        _workingDirectory = section["workingDirectory"];
+        _inputTemplate = section["inputTemplate"] ?? "{{persona}}\n\n{{prompt}}";
+    }
+
+    /// <inheritdoc />
+    public string Name => "local";
+
+    /// <inheritdoc />
+    public async Task<string> CompleteAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_command))
+        {
+            _logger.LogWarning("Local LLM command not configured. Echoing prompt.");
+            return $"{persona}{Environment.NewLine}{prompt}";
+        }
+
+        var payload = _inputTemplate
+            .Replace("{{persona}}", persona, StringComparison.Ordinal)
+            .Replace("{{prompt}}", prompt, StringComparison.Ordinal);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = _command!,
+            Arguments = _arguments ?? string.Empty,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (!string.IsNullOrWhiteSpace(_workingDirectory))
+        {
+            startInfo.WorkingDirectory = _workingDirectory;
+        }
+
+        using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        var outputBuilder = new StringBuilder();
+        var errorBuilder = new StringBuilder();
+
+        process.OutputDataReceived += (_, args) =>
+        {
+            if (args.Data is { Length: > 0 })
+            {
+                lock (outputBuilder)
+                {
+                    outputBuilder.AppendLine(args.Data);
+                }
+            }
+        };
+
+        process.ErrorDataReceived += (_, args) =>
+        {
+            if (args.Data is { Length: > 0 })
+            {
+                lock (errorBuilder)
+                {
+                    errorBuilder.AppendLine(args.Data);
+                }
+            }
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Unable to start local provider process.");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        await process.StandardInput.WriteAsync(payload.AsMemory(), cancellationToken).ConfigureAwait(false);
+        await process.StandardInput.FlushAsync().ConfigureAwait(false);
+        process.StandardInput.Close();
+
+        using var registration = cancellationToken.Register(() =>
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to terminate local LLM process on cancellation.");
+            }
+        });
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            var error = errorBuilder.ToString();
+            throw new InvalidOperationException($"Local provider failed with exit code {process.ExitCode}: {error}");
+        }
+
+        var response = outputBuilder.ToString().Trim();
+        if (string.IsNullOrWhiteSpace(response))
+        {
+            _logger.LogWarning("Local provider returned empty response.");
+        }
+
+        return response;
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncEnumerable<string>> StreamAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        var completion = await CompleteAsync(prompt, persona, cancellationToken).ConfigureAwait(false);
+        return CreateSingleChunk(completion);
+    }
+
+    /// <inheritdoc />
+    public int EstimateTokens(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        return Math.Max(1, text.Length / 3);
+    }
+
+    private static Task<IAsyncEnumerable<string>> CreateSingleChunk(string content)
+    {
+        async IAsyncEnumerable<string> Enumerate()
+        {
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                yield return content;
+            }
+
+            await Task.CompletedTask;
+        }
+
+        return Task.FromResult<IAsyncEnumerable<string>>(Enumerate());
+    }
+}

--- a/Tromby/src/TrombyApp/LLM/Adapters/MistralClient.cs
+++ b/Tromby/src/TrombyApp/LLM/Adapters/MistralClient.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tromby.LLM.Abstractions;
+
+namespace Tromby.LLM.Adapters;
+
+/// <summary>
+/// Adapter for the Mistral API.
+/// </summary>
+public sealed class MistralClient : ILLMClient
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<MistralClient> _logger;
+    private readonly string _endpoint;
+    private readonly string? _apiKey;
+    private readonly string _model;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MistralClient"/> class.
+    /// </summary>
+    public MistralClient(IHttpClientFactory httpClientFactory, IConfiguration configuration, ILogger<MistralClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+
+        var section = configuration.GetSection("llm:mistral");
+        _endpoint = section["endpoint"] ?? "https://api.mistral.ai/v1/chat/completions";
+        _apiKey = section["apiKey"];
+        _model = section["model"] ?? "mistral-large-latest";
+    }
+
+    /// <inheritdoc />
+    public string Name => "mistral";
+
+    /// <inheritdoc />
+    public async Task<string> CompleteAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_apiKey))
+        {
+            _logger.LogWarning("Mistral API key missing, returning simulated completion.");
+            return $"[Mistral simulé] {prompt}";
+        }
+
+        var client = _httpClientFactory.CreateClient(nameof(MistralClient));
+        var body = new
+        {
+            model = _model,
+            messages = new[]
+            {
+                new { role = "system", content = persona },
+                new { role = "user", content = prompt }
+            }
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint)
+        {
+            Content = JsonContent.Create(body, options: SerializerOptions)
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException($"Mistral completion failed: {response.StatusCode} - {error}");
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<MistralResponse>(SerializerOptions, cancellationToken).ConfigureAwait(false);
+        var completion = payload?.Choices?.FirstOrDefault()?.Message?.Content ?? string.Empty;
+        return completion;
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncEnumerable<string>> StreamAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        var completion = await CompleteAsync(prompt, persona, cancellationToken).ConfigureAwait(false);
+        return CreateSingleChunk(completion);
+    }
+
+    /// <inheritdoc />
+    public int EstimateTokens(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        return Math.Max(1, text.Length / 4);
+    }
+
+    private static Task<IAsyncEnumerable<string>> CreateSingleChunk(string content)
+    {
+        async IAsyncEnumerable<string> Enumerate()
+        {
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                yield return content;
+            }
+
+            await Task.CompletedTask;
+        }
+
+        return Task.FromResult<IAsyncEnumerable<string>>(Enumerate());
+    }
+
+    private sealed record MistralResponse(
+        [property: JsonPropertyName("choices")] IReadOnlyList<MistralChoice>? Choices);
+
+    private sealed record MistralChoice(
+        [property: JsonPropertyName("message")] MistralMessage? Message);
+
+    private sealed record MistralMessage(
+        [property: JsonPropertyName("content")] string? Content);
+}

--- a/Tromby/src/TrombyApp/LLM/Adapters/OpenAiClient.cs
+++ b/Tromby/src/TrombyApp/LLM/Adapters/OpenAiClient.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tromby.LLM.Abstractions;
+
+namespace Tromby.LLM.Adapters;
+
+/// <summary>
+/// Adapter for OpenAI compatible HTTP APIs.
+/// </summary>
+public sealed class OpenAiClient : ILLMClient
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OpenAiClient> _logger;
+    private readonly string _endpoint;
+    private readonly string? _apiKey;
+    private readonly string _model;
+    private readonly double _temperature;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenAiClient"/> class.
+    /// </summary>
+    public OpenAiClient(HttpClient httpClient, IConfiguration configuration, ILogger<OpenAiClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+
+        var section = configuration.GetSection("llm:openai");
+        _endpoint = section["endpoint"] ?? "https://api.openai.com/v1/chat/completions";
+        _apiKey = section["apiKey"];
+        _model = section["model"] ?? "gpt-4o-mini";
+        _temperature = section.GetValue<double?>("temperature") ?? 0.7d;
+
+        if (!string.IsNullOrWhiteSpace(_apiKey))
+        {
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+        }
+
+        var timeoutSeconds = section.GetValue("timeoutSeconds", 60);
+        if (timeoutSeconds > 0)
+        {
+            _httpClient.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        }
+    }
+
+    /// <inheritdoc />
+    public string Name => "openai";
+
+    /// <inheritdoc />
+    public async Task<string> CompleteAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_apiKey))
+        {
+            _logger.LogWarning("OpenAI API key missing, returning simulated completion.");
+            return $"[OpenAI simulé] {prompt}";
+        }
+
+        var body = new
+        {
+            model = _model,
+            messages = new[]
+            {
+                new { role = "system", content = persona },
+                new { role = "user", content = prompt }
+            },
+            temperature = _temperature,
+            stream = false
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint)
+        {
+            Content = JsonContent.Create(body, options: SerializerOptions)
+        };
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException($"OpenAI completion failed: {response.StatusCode} - {error}");
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<OpenAiResponse>(SerializerOptions, cancellationToken).ConfigureAwait(false);
+        var completion = payload?.Choices?.FirstOrDefault()?.Message?.Content ?? string.Empty;
+        return completion;
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncEnumerable<string>> StreamAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        var completion = await CompleteAsync(prompt, persona, cancellationToken).ConfigureAwait(false);
+        return CreateSingleChunk(completion);
+    }
+
+    /// <inheritdoc />
+    public int EstimateTokens(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        return Math.Max(1, text.Length / 4);
+    }
+
+    private static Task<IAsyncEnumerable<string>> CreateSingleChunk(string content)
+    {
+        async IAsyncEnumerable<string> Enumerate()
+        {
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                yield return content;
+            }
+
+            await Task.CompletedTask;
+        }
+
+        return Task.FromResult<IAsyncEnumerable<string>>(Enumerate());
+    }
+
+    private sealed record OpenAiResponse(
+        [property: JsonPropertyName("choices")] IReadOnlyList<OpenAiChoice>? Choices);
+
+    private sealed record OpenAiChoice(
+        [property: JsonPropertyName("message")] OpenAiMessage? Message);
+
+    private sealed record OpenAiMessage(
+        [property: JsonPropertyName("content")] string? Content);
+}

--- a/Tromby/src/TrombyApp/LLM/Adapters/XaiClient.cs
+++ b/Tromby/src/TrombyApp/LLM/Adapters/XaiClient.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tromby.LLM.Abstractions;
+
+namespace Tromby.LLM.Adapters;
+
+/// <summary>
+/// Adapter for xAI Grok models.
+/// </summary>
+public sealed class XaiClient : ILLMClient
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<XaiClient> _logger;
+    private readonly string _endpoint;
+    private readonly string? _apiKey;
+    private readonly string _model;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XaiClient"/> class.
+    /// </summary>
+    public XaiClient(IHttpClientFactory httpClientFactory, IConfiguration configuration, ILogger<XaiClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+
+        var section = configuration.GetSection("llm:xai");
+        _endpoint = section["endpoint"] ?? "https://api.x.ai/v1/chat/completions";
+        _apiKey = section["apiKey"];
+        _model = section["model"] ?? "grok-beta";
+    }
+
+    /// <inheritdoc />
+    public string Name => "xai";
+
+    /// <inheritdoc />
+    public async Task<string> CompleteAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_apiKey))
+        {
+            _logger.LogWarning("xAI API key missing, returning simulated completion.");
+            return $"[xAI simulé] {prompt}";
+        }
+
+        var client = _httpClientFactory.CreateClient(nameof(XaiClient));
+        var body = new
+        {
+            model = _model,
+            messages = new[]
+            {
+                new { role = "system", content = persona },
+                new { role = "user", content = prompt }
+            }
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint)
+        {
+            Content = JsonContent.Create(body, options: SerializerOptions)
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException($"xAI completion failed: {response.StatusCode} - {error}");
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<XaiResponse>(SerializerOptions, cancellationToken).ConfigureAwait(false);
+        var completion = payload?.Choices?.FirstOrDefault()?.Message?.Content ?? string.Empty;
+        return completion;
+    }
+
+    /// <inheritdoc />
+    public async Task<IAsyncEnumerable<string>> StreamAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        var completion = await CompleteAsync(prompt, persona, cancellationToken).ConfigureAwait(false);
+        return CreateSingleChunk(completion);
+    }
+
+    /// <inheritdoc />
+    public int EstimateTokens(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        return Math.Max(1, text.Length / 4);
+    }
+
+    private static Task<IAsyncEnumerable<string>> CreateSingleChunk(string content)
+    {
+        async IAsyncEnumerable<string> Enumerate()
+        {
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                yield return content;
+            }
+
+            await Task.CompletedTask;
+        }
+
+        return Task.FromResult<IAsyncEnumerable<string>>(Enumerate());
+    }
+
+    private sealed record XaiResponse(
+        [property: JsonPropertyName("choices")] IReadOnlyList<XaiChoice>? Choices);
+
+    private sealed record XaiChoice(
+        [property: JsonPropertyName("message")] XaiMessage? Message);
+
+    private sealed record XaiMessage(
+        [property: JsonPropertyName("content")] string? Content);
+}

--- a/Tromby/src/TrombyApp/LLM/Router/LLMProviderRouter.cs
+++ b/Tromby/src/TrombyApp/LLM/Router/LLMProviderRouter.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tromby.Core.Scheduling;
+using Tromby.Infra.Config;
+using Tromby.Infra.Metrics;
+using Tromby.LLM.Abstractions;
+
+namespace Tromby.LLM.Router;
+
+/// <summary>
+/// Routes prompts to the optimal provider while enforcing budgets, caching and scheduler preferences.
+/// </summary>
+public sealed class LLMProviderRouter
+{
+    private static readonly IReadOnlyList<string> QualityPriority = new[] { "openai", "gemini", "mistral", "xai", "local" };
+    private static readonly IReadOnlyList<string> EcoPriority = new[] { "local", "mistral", "xai", "gemini", "openai" };
+
+    private readonly IReadOnlyDictionary<string, ILLMClient> _clients;
+    private readonly IScheduler _scheduler;
+    private readonly ILogger<LLMProviderRouter> _logger;
+    private readonly IMetricsCollector _metrics;
+    private readonly ConcurrentDictionary<string, (DateTimeOffset expiresAt, string response)> _cache = new();
+    private readonly TimeSpan _cacheTtl;
+    private readonly BudgetLimits _limits;
+    private readonly IReadOnlyDictionary<string, decimal> _costsPer1K;
+    private readonly object _budgetLock = new();
+    private long _promptTokens;
+    private long _completionTokens;
+    private decimal _estimatedSpend;
+
+    /// <summary>
+    /// Initializes a new instance of the router.
+    /// </summary>
+    public LLMProviderRouter(
+        IEnumerable<ILLMClient> clients,
+        IScheduler scheduler,
+        IMetricsCollector metrics,
+        IConfigurationAdapter configurationAdapter,
+        IConfiguration configuration,
+        ILogger<LLMProviderRouter> logger)
+    {
+        _clients = clients.ToDictionary(client => client.Name, StringComparer.OrdinalIgnoreCase);
+        _scheduler = scheduler;
+        _metrics = metrics;
+        _logger = logger;
+        _cacheTtl = configurationAdapter.GetCacheTtl();
+        _limits = new BudgetLimits(
+            configuration.GetValue<int?>("budgets:limits:tokenBudget") ?? 0,
+            configuration.GetValue<decimal?>("budgets:limits:euroBudget") ?? 0m);
+
+        var configuredCosts = configuration
+            .GetSection("llm:costsPer1K")
+            .GetChildren()
+            .ToDictionary(
+                child => child.Key,
+                child => decimal.TryParse(child.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0m,
+                StringComparer.OrdinalIgnoreCase);
+
+        if (configuredCosts.Count == 0)
+        {
+            configuredCosts = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["openai"] = 15m,
+                ["mistral"] = 4m,
+                ["gemini"] = 7m,
+                ["xai"] = 5m,
+                ["local"] = 0m
+            };
+        }
+
+        _costsPer1K = configuredCosts;
+    }
+
+    /// <summary>
+    /// Sends a prompt through the selected provider with persona instructions.
+    /// </summary>
+    public async Task<string> SendAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        var cacheKey = ComputeCacheKey(prompt, persona);
+        if (_cache.TryGetValue(cacheKey, out var cached) && cached.expiresAt > DateTimeOffset.UtcNow)
+        {
+            _logger.LogDebug("Serving cached response for key {Key}.", cacheKey);
+            return cached.response;
+        }
+
+        var orderedClients = await ResolveClientsAsync(cancellationToken).ConfigureAwait(false);
+        Exception? lastError = null;
+        foreach (var client in orderedClients)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                _logger.LogInformation("Routing prompt to {Provider}", client.Name);
+                var response = await client.CompleteAsync(prompt, persona, cancellationToken).ConfigureAwait(false);
+                RegisterSuccess(client, prompt, response);
+                _cache[cacheKey] = (DateTimeOffset.UtcNow.Add(_cacheTtl), response);
+                return response;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Provider {Provider} failed, attempting fallback.", client.Name);
+                lastError = ex;
+            }
+        }
+
+        throw new InvalidOperationException("No LLM provider succeeded.", lastError);
+    }
+
+    /// <summary>
+    /// Streams a completion response chunk-by-chunk using provider fallbacks.
+    /// </summary>
+    public async Task<IAsyncEnumerable<string>> StreamAsync(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        var orderedClients = await ResolveClientsAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var client in orderedClients)
+        {
+            try
+            {
+                return await client.StreamAsync(prompt, persona, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Streaming failed with {Provider}, retrying next option.", client.Name);
+            }
+        }
+
+        return FallbackStream(prompt, persona, cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets the current budget snapshot for UI badges.
+    /// </summary>
+    public BudgetSnapshot GetBudgetSnapshot()
+    {
+        lock (_budgetLock)
+        {
+            var consumed = _promptTokens + _completionTokens;
+            var tokenBudget = _limits.TokenBudget;
+            var tokenRatio = tokenBudget > 0 ? Math.Clamp(1d - consumed / (double)tokenBudget, 0d, 1d) : 1d;
+            var euroBudget = _limits.EuroBudget;
+            var euroRatio = euroBudget > 0m ? Math.Clamp(1m - (_estimatedSpend / euroBudget), 0m, 1m) : 1m;
+            return new BudgetSnapshot(tokenRatio, euroRatio, consumed, tokenBudget, _estimatedSpend, euroBudget);
+        }
+    }
+
+    private async Task<IReadOnlyList<ILLMClient>> ResolveClientsAsync(CancellationToken cancellationToken)
+    {
+        var tier = await _scheduler.ResolveTargetTierAsync(cancellationToken).ConfigureAwait(false);
+        var preferred = string.Equals(tier, "premium", StringComparison.OrdinalIgnoreCase) ? QualityPriority : EcoPriority;
+        var sequence = new List<ILLMClient>(_clients.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in preferred)
+        {
+            if (_clients.TryGetValue(name, out var client) && seen.Add(client.Name))
+            {
+                sequence.Add(client);
+            }
+        }
+
+        foreach (var client in _clients.Values)
+        {
+            if (seen.Add(client.Name))
+            {
+                sequence.Add(client);
+            }
+        }
+
+        return sequence;
+    }
+
+    private void RegisterSuccess(ILLMClient client, string prompt, string response)
+    {
+        _metrics.TrackCompletion(client.Name);
+        var promptTokens = client.EstimateTokens(prompt);
+        var completionTokens = client.EstimateTokens(response);
+
+        lock (_budgetLock)
+        {
+            _promptTokens += promptTokens;
+            _completionTokens += completionTokens;
+
+            if (_limits.EuroBudget > 0 && _costsPer1K.TryGetValue(client.Name, out var costPer1K))
+            {
+                var totalTokens = promptTokens + completionTokens;
+                _estimatedSpend += (totalTokens / 1000m) * costPer1K;
+            }
+        }
+    }
+
+    private static string ComputeCacheKey(string prompt, string persona)
+    {
+        using var sha = SHA256.Create();
+        var buffer = Encoding.UTF8.GetBytes($"{persona}\u2029{prompt}");
+        return Convert.ToHexString(sha.ComputeHash(buffer));
+    }
+
+    private async IAsyncEnumerable<string> FallbackStream(string prompt, string persona, CancellationToken cancellationToken)
+    {
+        var completion = await SendAsync(prompt, persona, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(completion))
+        {
+            yield return completion;
+        }
+    }
+
+    /// <summary>
+    /// Represents budget state consumed by the router.
+    /// </summary>
+    public readonly struct BudgetSnapshot
+    {
+        public BudgetSnapshot(double tokenRatio, decimal euroRatio, long tokensConsumed, long tokenBudget, decimal eurosSpent, decimal euroBudget)
+        {
+            TokenRatio = tokenRatio;
+            EuroRatio = euroRatio;
+            TokensConsumed = tokensConsumed;
+            TokenBudget = tokenBudget;
+            EurosSpent = eurosSpent;
+            EuroBudget = euroBudget;
+        }
+
+        public double TokenRatio { get; }
+
+        public decimal EuroRatio { get; }
+
+        public long TokensConsumed { get; }
+
+        public long TokenBudget { get; }
+
+        public decimal EurosSpent { get; }
+
+        public decimal EuroBudget { get; }
+    }
+
+    private readonly struct BudgetLimits
+    {
+        public BudgetLimits(int tokenBudget, decimal euroBudget)
+        {
+            TokenBudget = tokenBudget;
+            EuroBudget = euroBudget;
+        }
+
+        public int TokenBudget { get; }
+
+        public decimal EuroBudget { get; }
+    }
+}

--- a/Tromby/src/TrombyApp/Security/ConsentService.cs
+++ b/Tromby/src/TrombyApp/Security/ConsentService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Windows.Security.Credentials;
+
+namespace Tromby.Security;
+
+/// <summary>
+/// Persists consent via Windows Credential Locker and revalidates based on policy hash.
+/// </summary>
+public sealed class ConsentService : IConsentService
+{
+    private const string RESOURCE_NAME = "Tromby/Consent";
+    private readonly PolicyManager _policyManager;
+    private readonly ILogger<ConsentService> _logger;
+    private readonly PasswordVault _vault = new();
+
+    /// <summary>
+    /// Initializes a new instance of the consent service.
+    /// </summary>
+    public ConsentService(PolicyManager policyManager, ILogger<ConsentService> logger)
+    {
+        _policyManager = policyManager;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<bool> HasConsentAsync(CancellationToken cancellationToken)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var credential = _vault.Retrieve(RESOURCE_NAME, Environment.UserName);
+                credential.RetrievePassword();
+                var storedHash = credential.Password;
+                var currentHash = _policyManager.CurrentPolicyHash;
+                var matches = string.Equals(storedHash, currentHash, StringComparison.Ordinal);
+                if (!matches)
+                {
+                    _logger.LogInformation("Consent hash mismatch detected. Stored={Stored} Expected={Expected}.", storedHash, currentHash);
+                }
+
+                return matches;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogInformation(ex, "Consent not present in credential locker.");
+                return false;
+            }
+        }, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task StoreConsentAsync(string policyHash, CancellationToken cancellationToken)
+    {
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var hashToPersist = string.IsNullOrWhiteSpace(policyHash) ? _policyManager.CurrentPolicyHash : policyHash;
+            try
+            {
+                var existing = _vault.Retrieve(RESOURCE_NAME, Environment.UserName);
+                _vault.Remove(existing);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "No existing consent credential to remove.");
+            }
+
+            var credential = new PasswordCredential(RESOURCE_NAME, Environment.UserName, hashToPersist);
+            _vault.Add(credential);
+            _logger.LogInformation("Consent stored for hash {Hash}.", hashToPersist);
+        }, cancellationToken);
+    }
+}

--- a/Tromby/src/TrombyApp/Security/IConsentService.cs
+++ b/Tromby/src/TrombyApp/Security/IConsentService.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Security;
+
+/// <summary>
+/// Handles user consent storage and policy revalidation.
+/// </summary>
+public interface IConsentService
+{
+    /// <summary>
+    /// Checks if the user has already provided consent matching current policy hash.
+    /// </summary>
+    Task<bool> HasConsentAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Stores user consent with the provided policy hash.
+    /// </summary>
+    Task StoreConsentAsync(string policyHash, CancellationToken cancellationToken);
+}

--- a/Tromby/src/TrombyApp/Security/PolicyManager.cs
+++ b/Tromby/src/TrombyApp/Security/PolicyManager.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+
+namespace Tromby.Security;
+
+/// <summary>
+/// Provides access to policy configuration and ensures re-consent when policy changes.
+/// </summary>
+public sealed class PolicyManager
+{
+    private readonly IConfiguration _configuration;
+    private readonly Lazy<string> _policyHash;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PolicyManager"/> class.
+    /// </summary>
+    public PolicyManager(IConfiguration configuration)
+    {
+        _configuration = configuration;
+        _policyHash = new Lazy<string>(ComputePolicyHash, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <summary>
+    /// Gets the current policy hash fingerprint.
+    /// </summary>
+    public string CurrentPolicyHash => _policyHash.Value;
+
+    /// <summary>
+    /// Ensures the stored consent matches the current policy fingerprint.
+    /// </summary>
+    public async Task EnsurePolicyUpToDateAsync(IConsentService consentService, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!await consentService.HasConsentAsync(cancellationToken).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("Consent is required for the current policy hash.");
+        }
+    }
+
+    private string ComputePolicyHash()
+    {
+        var section = _configuration.GetSection("policy");
+        var builder = new StringBuilder();
+        AppendSection(section, builder, string.Empty);
+        using var sha = SHA256.Create();
+        var computed = Convert.ToHexString(sha.ComputeHash(Encoding.UTF8.GetBytes(builder.ToString())));
+        var declared = section["hash"];
+        return string.IsNullOrWhiteSpace(declared) ? computed : $"{declared}:{computed}";
+    }
+
+    private static void AppendSection(IConfiguration section, StringBuilder builder, string prefix)
+    {
+        foreach (var child in section.GetChildren().OrderBy(child => child.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            var key = string.IsNullOrEmpty(prefix) ? child.Key : $"{prefix}:{child.Key}";
+            if (key.EndsWith(":hash", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (child.Value is not null)
+            {
+                builder.Append(key).Append('=').Append(child.Value).Append(';');
+            }
+
+            AppendSection(child, builder, key);
+        }
+    }
+}

--- a/Tromby/src/TrombyApp/Tools/Mcp/IMcpClient.cs
+++ b/Tromby/src/TrombyApp/Tools/Mcp/IMcpClient.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Tools.Mcp;
+
+/// <summary>
+/// Minimal MCP client abstraction for executing local actions.
+/// </summary>
+public interface IMcpClient
+{
+    /// <summary>
+    /// Executes a named MCP action.
+    /// </summary>
+    Task ExecuteActionAsync(string actionName, string payload, CancellationToken cancellationToken);
+}

--- a/Tromby/src/TrombyApp/Tools/Mcp/McpClient.cs
+++ b/Tromby/src/TrombyApp/Tools/Mcp/McpClient.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Tromby.Tools.Mcp;
+
+/// <summary>
+/// Placeholder MCP client bridging to local action providers.
+/// </summary>
+public sealed class McpClient : IMcpClient
+{
+    private readonly ILogger<McpClient> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="McpClient"/> class.
+    /// </summary>
+    public McpClient(ILogger<McpClient> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task ExecuteActionAsync(string actionName, string payload, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Executing MCP action {Action} with payload length {Length}.", actionName, payload?.Length ?? 0);
+        // TODO: Integrate with MCP runtime with sandbox enforcement.
+        return Task.CompletedTask;
+    }
+}

--- a/Tromby/src/TrombyApp/Tools/Sandbox/IShellSandbox.cs
+++ b/Tromby/src/TrombyApp/Tools/Sandbox/IShellSandbox.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Tools.Sandbox;
+
+/// <summary>
+/// Executes PowerShell scripts within a constrained sandbox.
+/// </summary>
+public interface IShellSandbox
+{
+    /// <summary>
+    /// Executes a script with optional confirmation.
+    /// </summary>
+    Task<string> ExecuteAsync(string script, bool requireConfirmation, CancellationToken cancellationToken);
+}

--- a/Tromby/src/TrombyApp/Tools/Sandbox/PowerShellSandbox.cs
+++ b/Tromby/src/TrombyApp/Tools/Sandbox/PowerShellSandbox.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Tromby.Tools.Sandbox;
+
+/// <summary>
+/// Runs PowerShell commands with whitelist enforcement and optional confirmation prompts.
+/// </summary>
+public sealed class PowerShellSandbox : IShellSandbox
+{
+    private readonly ILogger<PowerShellSandbox> _logger;
+    private readonly HashSet<string> _whitelist;
+    private readonly HashSet<string> _requireConfirm;
+    private readonly TimeSpan _executionTimeout;
+    private readonly int _ioBudgetBytes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PowerShellSandbox"/> class.
+    /// </summary>
+    public PowerShellSandbox(ILogger<PowerShellSandbox> logger, IConfiguration configuration)
+    {
+        _logger = logger;
+        var actionsSection = configuration.GetSection("policy:actions");
+        _whitelist = actionsSection.GetSection("whitelist").Get<HashSet<string>>() ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        _requireConfirm = actionsSection.GetSection("requireConfirm").Get<HashSet<string>>() ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var timeoutSeconds = configuration.GetValue<int?>("policy:limits:sandboxTimeoutSeconds") ?? 10;
+        _executionTimeout = TimeSpan.FromSeconds(Math.Clamp(timeoutSeconds, 1, 300));
+        _ioBudgetBytes = Math.Max(1024, configuration.GetValue<int?>("policy:limits:ioBytesPerMinute") ?? 1024 * 1024);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ExecuteAsync(string script, bool requireConfirmation, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!_whitelist.Contains(script))
+        {
+            throw new InvalidOperationException("Script not in whitelist.");
+        }
+
+        if (_requireConfirm.Contains(script) && !requireConfirmation)
+        {
+            throw new InvalidOperationException("Explicit confirmation required for this script.");
+        }
+
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        linkedCts.CancelAfter(_executionTimeout);
+
+        using var powerShell = PowerShell.Create();
+        powerShell.AddScript(script);
+
+        _logger.LogInformation("Executing sandboxed script {Script} with timeout {Timeout}s and IO cap {IoBudget} bytes.", script, _executionTimeout.TotalSeconds, _ioBudgetBytes);
+
+        var invocationTask = Task.Run(() => powerShell.Invoke(), CancellationToken.None);
+        Task completedTask;
+        try
+        {
+            completedTask = await Task.WhenAny(invocationTask, Task.Delay(Timeout.Infinite, linkedCts.Token)).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            powerShell.Stop();
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            powerShell.Stop();
+            throw new TimeoutException($"Script execution exceeded {_executionTimeout.TotalSeconds} seconds.");
+        }
+
+        if (completedTask != invocationTask)
+        {
+            powerShell.Stop();
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new TimeoutException($"Script execution exceeded {_executionTimeout.TotalSeconds} seconds.");
+        }
+
+        var results = await invocationTask.ConfigureAwait(false);
+
+        if (powerShell.Streams.Error.Count > 0)
+        {
+            var errorPayload = string.Join(Environment.NewLine, powerShell.Streams.Error.Select(e => e.ToString()));
+            throw new InvalidOperationException($"PowerShell reported errors: {errorPayload}");
+        }
+
+        var output = string.Join(Environment.NewLine, results);
+        var sanitized = EnforceIoBudget(output);
+        if (!ReferenceEquals(output, sanitized))
+        {
+            _logger.LogWarning("Output truncated to {Limit} bytes for script {Script}.", _ioBudgetBytes, script);
+        }
+
+        return sanitized;
+    }
+
+    private string EnforceIoBudget(string output)
+    {
+        if (string.IsNullOrEmpty(output))
+        {
+            return output;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(output);
+        if (bytes.Length <= _ioBudgetBytes)
+        {
+            return output;
+        }
+
+        return Encoding.UTF8.GetString(bytes, 0, _ioBudgetBytes);
+    }
+}

--- a/Tromby/src/TrombyApp/TrombyApp.csproj
+++ b/Tromby/src/TrombyApp/TrombyApp.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWinUI>true</UseWinUI>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
+    <RootNamespace>Tromby</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240802000" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="System.Management.Automation" Version="7.3.6" />
+    <PackageReference Include="System.Speech" Version="7.0.0" />
+    <PackageReference Include="YamlDotNet" Version="13.5.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\tests\Tromby.Tests\Tromby.Tests.csproj" Condition="'$(BuildingInsideVisualStudio)' == 'true'" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="App.xaml" />
+    <None Remove="UI/Views/ShellWindow.xaml" />
+    <None Remove="UI/Views/SettingsView.xaml" />
+    <None Remove="UI/Components/OnboardingCard.xaml" />
+    <None Remove="UI/Styles/Colors.xaml" />
+    <None Remove="UI/Styles/Theme.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml" />
+    <Page Include="UI/Views/ShellWindow.xaml" />
+    <Page Include="UI/Views/SettingsView.xaml" />
+    <Page Include="UI/Components/OnboardingCard.xaml" />
+    <Page Include="UI/Styles/Colors.xaml" />
+    <Page Include="UI/Styles/Theme.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assets/Icons/tromby.ico" />
+  </ItemGroup>
+</Project>

--- a/Tromby/src/TrombyApp/UI/Components/OnboardingCard.xaml
+++ b/Tromby/src/TrombyApp/UI/Components/OnboardingCard.xaml
@@ -1,0 +1,16 @@
+<UserControl
+    x:Class="Tromby.UI.Components.OnboardingCard"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Border Background="#1AFFFFFF" CornerRadius="12" Padding="16" BorderBrush="{StaticResource AccentBrush}" BorderThickness="1">
+        <StackPanel Spacing="12">
+            <TextBlock Text="Bienvenue sur Tromby" Style="{StaticResource OverlayTitleText}" />
+            <TextBlock Text="Tromby fonctionne comme un copilote overlay. Configurez votre consentement et vos providers pour commencer." TextWrapping="Wrap" />
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <Button Content="Donner mon consentement" HorizontalAlignment="Left" Click="OnConsentClick" />
+                <CheckBox Content="Ne plus afficher" VerticalAlignment="Center" Checked="OnNeverShowChanged" Unchecked="OnNeverShowChanged" />
+            </StackPanel>
+            <Button Content="J'ai compris" HorizontalAlignment="Right" Click="OnDismissClick" />
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Tromby/src/TrombyApp/UI/Components/OnboardingCard.xaml.cs
+++ b/Tromby/src/TrombyApp/UI/Components/OnboardingCard.xaml.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Tromby.UI.Components;
+
+/// <summary>
+/// Lightweight onboarding card displayed on first launch.
+/// </summary>
+public sealed partial class OnboardingCard : UserControl
+{
+    private bool _neverShow;
+
+    /// <summary>
+    /// Raised when the onboarding is dismissed.
+    /// </summary>
+    public event EventHandler<OnboardingDismissedEventArgs>? Dismissed;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    public OnboardingCard()
+    {
+        InitializeComponent();
+    }
+
+    private void OnNeverShowChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is CheckBox checkBox)
+        {
+            _neverShow = checkBox.IsChecked == true;
+        }
+    }
+
+    private void OnConsentClick(object sender, RoutedEventArgs e)
+    {
+        Visibility = Visibility.Collapsed;
+        Dismissed?.Invoke(this, new OnboardingDismissedEventArgs(_neverShow, true));
+    }
+
+    private void OnDismissClick(object sender, RoutedEventArgs e)
+    {
+        Visibility = Visibility.Collapsed;
+        Dismissed?.Invoke(this, new OnboardingDismissedEventArgs(_neverShow, false));
+    }
+}
+
+/// <summary>
+/// Event payload for onboarding dismissal actions.
+/// </summary>
+public sealed class OnboardingDismissedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the event args.
+    /// </summary>
+    public OnboardingDismissedEventArgs(bool dontShowAgain, bool consentRequested)
+    {
+        DontShowAgain = dontShowAgain;
+        ConsentRequested = consentRequested;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the onboarding should not reappear.
+    /// </summary>
+    public bool DontShowAgain { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the consent button was used.
+    /// </summary>
+    public bool ConsentRequested { get; }
+}

--- a/Tromby/src/TrombyApp/UI/Components/WindowExtensions.cs
+++ b/Tromby/src/TrombyApp/UI/Components/WindowExtensions.cs
@@ -1,0 +1,94 @@
+using System;
+using Microsoft.UI.Xaml;
+using WinRT.Interop;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace Tromby.UI.Components;
+
+/// <summary>
+/// Extension helpers for WinUI <see cref="Window"/> interop.
+/// </summary>
+public static class WindowExtensions
+{
+    /// <summary>
+    /// Gets the native handle for a WinUI window.
+    /// </summary>
+    /// <param name="window">Target window.</param>
+    /// <returns>Native HWND.</returns>
+    public static IntPtr GetWindowHandle(this Window window)
+    {
+        return WindowNative.GetWindowHandle(window);
+    }
+}
+
+/// <summary>
+/// Provides an event bridge for receiving window messages.
+/// </summary>
+public static class HwndExtensions
+{
+    /// <summary>
+    /// Raised when a window message is received for the overlay handle.
+    /// </summary>
+    public static event EventHandler<WindowMessageEventArgs>? MessageReceived;
+
+    private static bool _initialized;
+
+    /// <summary>
+    /// Initializes message hook for a given window handle.
+    /// </summary>
+    /// <param name="window">WinUI window to monitor.</param>
+    public static void EnsureHook(Window window)
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        var hwnd = new HWND(window.GetWindowHandle());
+        WindowMessageMonitor.Start(hwnd, (msg) => MessageReceived?.Invoke(window, msg));
+        _initialized = true;
+    }
+}
+
+/// <summary>
+/// Event arguments for window messages.
+/// </summary>
+public sealed class WindowMessageEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    public WindowMessageEventArgs(uint messageId, int wParam, int lParam)
+    {
+        MessageId = messageId;
+        WParam = wParam;
+        LParam = lParam;
+    }
+
+    /// <summary>
+    /// Gets the Windows message ID.
+    /// </summary>
+    public uint MessageId { get; }
+
+    /// <summary>
+    /// Gets the WParam payload.
+    /// </summary>
+    public int WParam { get; }
+
+    /// <summary>
+    /// Gets the LParam payload.
+    /// </summary>
+    public int LParam { get; }
+}
+
+internal static class WindowMessageMonitor
+{
+    /// <summary>
+    /// Starts listening for window messages on the provided handle.
+    /// </summary>
+    public static void Start(HWND hwnd, Action<WindowMessageEventArgs> callback)
+    {
+        // TODO: Implement message hook using SubclassWndProc and ensure thread-safety.
+    }
+}

--- a/Tromby/src/TrombyApp/UI/Styles/Colors.xaml
+++ b/Tromby/src/TrombyApp/UI/Styles/Colors.xaml
@@ -1,0 +1,7 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Color x:Key="OverlayBackgroundColor">#CC1F1F1F</Color>
+    <SolidColorBrush x:Key="OverlayBackgroundBrush" Color="{StaticResource OverlayBackgroundColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="White" />
+    <SolidColorBrush x:Key="AccentBrush" Color="#FF4C8BF5" />
+</ResourceDictionary>

--- a/Tromby/src/TrombyApp/UI/Styles/Theme.xaml
+++ b/Tromby/src/TrombyApp/UI/Styles/Theme.xaml
@@ -1,0 +1,9 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Thickness x:Key="OverlayPadding">12</Thickness>
+    <Style TargetType="TextBlock" x:Key="OverlayTitleText">
+        <Setter Property="FontSize" Value="20" />
+        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+</ResourceDictionary>

--- a/Tromby/src/TrombyApp/UI/ViewModels/SettingsViewModel.cs
+++ b/Tromby/src/TrombyApp/UI/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Tromby.Core.Persona;
+using Tromby.Core.Scheduling;
+
+namespace Tromby.UI.ViewModels;
+
+/// <summary>
+/// Settings view model exposing configurable policies and scheduler parameters.
+/// </summary>
+public partial class SettingsViewModel : ObservableObject
+{
+    private readonly IPersonaManager _personaManager;
+    private readonly IScheduler _scheduler;
+    private readonly TimeSpan _defaultQualityStart;
+    private readonly TimeSpan _defaultQualityEnd;
+    private readonly int _defaultOverride;
+    private readonly string _defaultMode;
+
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    public SettingsViewModel(IPersonaManager personaManager, IScheduler scheduler)
+    {
+        _personaManager = personaManager;
+        _scheduler = scheduler;
+        PersonaPresets = new ObservableCollection<string>(_personaManager.GetPresets());
+        _defaultQualityStart = SchedulerReflection.GetTimeSpan(_scheduler, "QualityStart", TimeSpan.FromHours(8));
+        _defaultQualityEnd = SchedulerReflection.GetTimeSpan(_scheduler, "QualityEnd", TimeSpan.FromHours(18));
+        _defaultOverride = SchedulerReflection.GetInt32(_scheduler, "OverrideMinutes", 0);
+
+        _qualityStart = _defaultQualityStart;
+        _qualityEnd = _defaultQualityEnd;
+        _overrideMinutes = _defaultOverride;
+        _defaultMode = _scheduler.ActiveMode;
+        _selectedMode = _defaultMode;
+        _selectedPersona = PersonaPresets.FirstOrDefault() ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(_selectedPersona))
+        {
+            _personaManager.SetPersona(_selectedPersona);
+        }
+
+        ApplySchedulerCommand = new AsyncRelayCommand(ApplySchedulerAsync);
+        ResetSchedulerCommand = new RelayCommand(ResetScheduler);
+    }
+
+    /// <summary>
+    /// Gets the available persona presets.
+    /// </summary>
+    public ObservableCollection<string> PersonaPresets { get; }
+
+    /// <summary>
+    /// Gets available mode options.
+    /// </summary>
+    public string[] ModeOptions { get; } = { "Qualité", "Éco", "Auto" };
+
+    /// <summary>
+    /// Command to persist scheduler changes.
+    /// </summary>
+    public IAsyncRelayCommand ApplySchedulerCommand { get; }
+
+    /// <summary>
+    /// Command to reset scheduler to defaults.
+    /// </summary>
+    public IRelayCommand ResetSchedulerCommand { get; }
+
+    [ObservableProperty]
+    private string _selectedMode = "Qualité";
+
+    [ObservableProperty]
+    private TimeSpan _qualityStart;
+
+    [ObservableProperty]
+    private TimeSpan _qualityEnd;
+
+    [ObservableProperty]
+    private double _overrideMinutes;
+
+    [ObservableProperty]
+    private string _selectedPersona = string.Empty;
+
+    partial void OnSelectedModeChanged(string value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            _scheduler.SwitchMode(value);
+        }
+    }
+
+    partial void OnSelectedPersonaChanged(string value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            _personaManager.SetPersona(value);
+        }
+    }
+
+    private async Task ApplySchedulerAsync()
+    {
+        SchedulerReflection.SetTimeSpan(_scheduler, "QualityStart", QualityStart);
+        SchedulerReflection.SetTimeSpan(_scheduler, "QualityEnd", QualityEnd);
+        SchedulerReflection.SetInt32(_scheduler, "OverrideMinutes", (int)Math.Clamp(OverrideMinutes, 0, int.MaxValue));
+        _scheduler.SwitchMode(SelectedMode);
+        WeakReferenceMessenger.Default.Send(new SchedulerUpdatedMessage());
+        await Task.CompletedTask;
+    }
+
+    private void ResetScheduler()
+    {
+        QualityStart = _defaultQualityStart;
+        QualityEnd = _defaultQualityEnd;
+        OverrideMinutes = _defaultOverride;
+        SelectedMode = _defaultMode;
+    }
+}
+
+internal static class SchedulerReflection
+{
+    public static TimeSpan GetTimeSpan(IScheduler scheduler, string propertyName, TimeSpan fallback)
+    {
+        var property = scheduler.GetType().GetProperty(propertyName);
+        if (property is not null && property.PropertyType == typeof(TimeSpan))
+        {
+            var value = property.GetValue(scheduler);
+            if (value is TimeSpan timeSpan)
+            {
+                return timeSpan;
+            }
+        }
+
+        return fallback;
+    }
+
+    public static void SetTimeSpan(IScheduler scheduler, string propertyName, TimeSpan value)
+    {
+        var property = scheduler.GetType().GetProperty(propertyName);
+        if (property is not null && property.PropertyType == typeof(TimeSpan) && property.CanWrite)
+        {
+            property.SetValue(scheduler, value);
+        }
+    }
+
+    public static int GetInt32(IScheduler scheduler, string propertyName, int fallback)
+    {
+        var property = scheduler.GetType().GetProperty(propertyName);
+        if (property is not null && property.PropertyType == typeof(int))
+        {
+            var value = property.GetValue(scheduler);
+            if (value is int number)
+            {
+                return number;
+            }
+        }
+
+        return fallback;
+    }
+
+    public static void SetInt32(IScheduler scheduler, string propertyName, int value)
+    {
+        var property = scheduler.GetType().GetProperty(propertyName);
+        if (property is not null && property.PropertyType == typeof(int) && property.CanWrite)
+        {
+            property.SetValue(scheduler, value);
+        }
+    }
+}
+
+internal sealed class SchedulerUpdatedMessage
+{
+}

--- a/Tromby/src/TrombyApp/UI/ViewModels/ShellViewModel.cs
+++ b/Tromby/src/TrombyApp/UI/ViewModels/ShellViewModel.cs
@@ -1,0 +1,294 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using Tromby.Core.Orchestration;
+using Tromby.Core.Persona;
+using Tromby.Core.Scheduling;
+using Tromby.Core.Sessions;
+using Tromby.Security;
+using Tromby.LLM.Router;
+using Tromby.Infra;
+using Tromby.Infra.Metrics;
+
+namespace Tromby.UI.ViewModels;
+
+/// <summary>
+/// View model for the shell overlay orchestrating user interactions and background state.
+/// </summary>
+public partial class ShellViewModel : ObservableRecipient, IDisposable
+{
+    private readonly IOverlayOrchestrator _orchestrator;
+    private readonly IPersonaManager _personaManager;
+    private readonly IScheduler _scheduler;
+    private readonly IConsentService _consentService;
+    private readonly ISessionStore _sessionStore;
+    private readonly PolicyManager _policyManager;
+    private readonly LLMProviderRouter _router;
+    private readonly ILogger<ShellViewModel> _logger;
+    private readonly IMetricsCollector _metrics;
+    private readonly BudgetService? _budgetService;
+    private readonly CancellationTokenSource _cts = new();
+    private string _budgetBadge = "Budget indisponible";
+    private BudgetSnapshot? _lastBudgetSnapshot;
+    private QualityMode _lastBudgetMode = QualityMode.Qualite;
+    private bool _hasBudget;
+
+    [ObservableProperty]
+    private string _activeMode = "Qualité";
+
+    [ObservableProperty]
+    private bool _showOnboarding = true;
+
+    [ObservableProperty]
+    private string _lastSessionPreview = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the view model.
+    /// </summary>
+    public ShellViewModel(
+        IOverlayOrchestrator orchestrator,
+        IPersonaManager personaManager,
+        IScheduler scheduler,
+        IConsentService consentService,
+        ISessionStore sessionStore,
+        PolicyManager policyManager,
+        LLMProviderRouter router,
+        IMetricsCollector metrics,
+        ILogger<ShellViewModel> logger)
+    {
+        _orchestrator = orchestrator;
+        _personaManager = personaManager;
+        _scheduler = scheduler;
+        _consentService = consentService;
+        _sessionStore = sessionStore;
+        _policyManager = policyManager;
+        _router = router;
+        _metrics = metrics;
+        _logger = logger;
+
+        try
+        {
+            var budgetsPath = Path.Combine(AppContext.BaseDirectory, "config", "budgets.json");
+            _budgetService = new BudgetService(budgetsPath);
+            _hasBudget = true;
+        }
+        catch (Exception ex)
+        {
+            _hasBudget = false;
+            _logger.LogWarning(ex, "Budget service initialisation failed.");
+        }
+
+        TriggerInteractionCommand = new AsyncRelayCommand(TriggerInteractionAsync);
+        OpenSettingsCommand = new RelayCommand(OpenSettings);
+        DemoReserveCommand = new RelayCommand(DemoReserve);
+        ResumeAsync(_cts.Token).FireAndForget(_logger);
+        RefreshBadges();
+    }
+
+    /// <summary>
+    /// Command that triggers a new LLM interaction.
+    /// </summary>
+    public IAsyncRelayCommand TriggerInteractionCommand { get; }
+
+    /// <summary>
+    /// Command to open the settings overlay.
+    /// </summary>
+    public IRelayCommand OpenSettingsCommand { get; }
+
+    /// <summary>
+    /// Command triggering a demo reservation of budget usage.
+    /// </summary>
+    public IRelayCommand DemoReserveCommand { get; }
+
+    private async Task ResumeAsync(CancellationToken token)
+    {
+        try
+        {
+            await _policyManager.EnsurePolicyUpToDateAsync(_consentService, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (InvalidOperationException)
+        {
+            ShowOnboarding = true;
+            LastSessionPreview = string.Empty;
+            RefreshBadges();
+            return;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Policy validation failed.");
+            ShowOnboarding = true;
+            LastSessionPreview = string.Empty;
+            return;
+        }
+
+        try
+        {
+            await _sessionStore.RestoreAsync(token).ConfigureAwait(false);
+            if (_sessionStore is DpapiSessionStore dpapiStore)
+            {
+                LastSessionPreview = dpapiStore.LastSnapshot;
+            }
+
+            ShowOnboarding = false;
+            ActiveMode = _scheduler.ActiveMode;
+            RefreshBadges();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to resume session state.");
+        }
+    }
+
+    private async Task TriggerInteractionAsync()
+    {
+        await _orchestrator.ExecuteAsync(_cts.Token).ConfigureAwait(false);
+        RefreshBadges();
+
+        if (_hasBudget && _lastBudgetSnapshot is { } snapshot)
+        {
+            _logger.LogDebug(
+                "Budget snapshot mode={Mode} tokens={Tokens}/{Budget} euros={Euros}/{EuroBudget} percent={Percent}%.",
+                _lastBudgetMode,
+                snapshot.DayTokensUsed,
+                snapshot.DayTokensCap,
+                snapshot.DayCostUsed,
+                snapshot.DayCostCap,
+                snapshot.DayPercent);
+        }
+    }
+
+    private void OpenSettings()
+    {
+        // TODO: Navigate to settings view.
+    }
+
+    private void DemoReserve()
+    {
+        if (_budgetService is null)
+        {
+            return;
+        }
+
+        var prefersQuality = !string.Equals(_scheduler.ActiveMode, "Éco", StringComparison.OrdinalIgnoreCase);
+        var effectiveQuality = _scheduler.ComputeEffectiveMode(prefersQuality, _scheduler.QualityStart, _scheduler.QualityEnd, DateTime.Now);
+        var mode = effectiveQuality ? QualityMode.Qualite : QualityMode.Eco;
+
+        var success = _budgetService.TryConsume(mode, Guid.Empty, 500, 0.05m, out var snapshot, out var softCap);
+        if (!success)
+        {
+            _logger.LogInformation("Demo reserve blocked by hard cap for mode {Mode}.", mode);
+        }
+
+        _metrics.TrackBudgetUsed(mode.ToString(), snapshot.DayTokensUsed, snapshot.DayCostUsed, snapshot.DayPercent, softCap, snapshot.IsHardCapReached);
+        RefreshBadges();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+
+    internal string BuildBudgetBadge()
+    {
+        if (!_hasBudget)
+        {
+            return "Budget indisponible";
+        }
+
+        var badge = _budgetBadge;
+        var overrideMs = _scheduler.OverrideMsRemaining();
+        if (overrideMs > 0)
+        {
+            var remaining = Math.Max(1, (int)Math.Ceiling(overrideMs / 60000d));
+            badge += $" • Override {remaining} min";
+        }
+
+        return badge;
+    }
+
+    internal void UpdateBudgetBadge()
+    {
+        if (!TryGetBudgetSnapshot(out var mode, out var snapshot))
+        {
+            _budgetBadge = "Budget indisponible";
+            _lastBudgetSnapshot = null;
+            _lastBudgetMode = QualityMode.Qualite;
+            _hasBudget = false;
+            return;
+        }
+
+        _hasBudget = true;
+        _lastBudgetMode = mode;
+        _lastBudgetSnapshot = snapshot;
+
+        var label = mode == QualityMode.Qualite ? "Qualité" : "Éco";
+        label += $" • {snapshot.DayPercent}%";
+
+        if (snapshot.IsHardCapReached)
+        {
+            label += " ⚠ Hard cap";
+        }
+        else if (snapshot.SoftCapReached)
+        {
+            label += " • Soft cap";
+        }
+
+        _budgetBadge = label;
+        _metrics.TrackBudgetUsed(mode.ToString(), snapshot.DayTokensUsed, snapshot.DayCostUsed, snapshot.DayPercent, snapshot.SoftCapReached, snapshot.IsHardCapReached);
+    }
+
+    private bool TryGetBudgetSnapshot(out QualityMode mode, out BudgetSnapshot snapshot)
+    {
+        mode = QualityMode.Qualite;
+        snapshot = null!;
+
+        if (_budgetService is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var prefersQuality = !string.Equals(_scheduler.ActiveMode, "Éco", StringComparison.OrdinalIgnoreCase);
+            var effectiveQuality = _scheduler.ComputeEffectiveMode(prefersQuality, _scheduler.QualityStart, _scheduler.QualityEnd, DateTime.Now);
+            mode = effectiveQuality ? QualityMode.Qualite : QualityMode.Eco;
+            snapshot = _budgetService.GetSnapshot(mode);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to compute budget snapshot.");
+            return false;
+        }
+    }
+
+}
+
+internal static class TaskExtensions
+{
+    public static async void FireAndForget(this Task task, ILogger logger)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "FireAndForget task failed.");
+        }
+    }
+}

--- a/Tromby/src/TrombyApp/UI/Views/SettingsView.xaml
+++ b/Tromby/src/TrombyApp/UI/Views/SettingsView.xaml
@@ -1,0 +1,48 @@
+<Page
+    x:Class="Tromby.UI.Views.SettingsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vm="using:Tromby.UI.ViewModels"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+    <Page.DataContext>
+        <vm:SettingsViewModel />
+    </Page.DataContext>
+    <ScrollViewer>
+        <StackPanel Spacing="20" Padding="16">
+            <TextBlock Text="Réglages Tromby" Style="{StaticResource OverlayTitleText}" />
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="Mode d'orchestration" FontSize="18" FontWeight="SemiBold" />
+                <controls:ComboBox
+                    Header="Mode actif"
+                    ItemsSource="{x:Bind ViewModel.ModeOptions, Mode=OneWay}"
+                    SelectedItem="{x:Bind ViewModel.SelectedMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <controls:NumberBox
+                    Header="Override temporaire (minutes)"
+                    Minimum="0"
+                    Maximum="240"
+                    Value="{x:Bind ViewModel.OverrideMinutes, Mode=TwoWay}" />
+                <controls:TimePicker
+                    Header="Début Qualité"
+                    ClockIdentifier="24HourClock"
+                    Time="{x:Bind ViewModel.QualityStart, Mode=TwoWay}" />
+                <controls:TimePicker
+                    Header="Fin Qualité"
+                    ClockIdentifier="24HourClock"
+                    Time="{x:Bind ViewModel.QualityEnd, Mode=TwoWay}" />
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="12">
+                    <Button Content="Appliquer" Command="{x:Bind ViewModel.ApplySchedulerCommand}" />
+                    <Button Content="Réinitialiser" Command="{x:Bind ViewModel.ResetSchedulerCommand}" />
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Spacing="12">
+                <TextBlock Text="Persona" FontSize="18" FontWeight="SemiBold" />
+                <controls:ComboBox
+                    Header="Preset"
+                    ItemsSource="{x:Bind ViewModel.PersonaPresets, Mode=OneWay}"
+                    SelectedItem="{x:Bind ViewModel.SelectedPersona, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/Tromby/src/TrombyApp/UI/Views/SettingsView.xaml.cs
+++ b/Tromby/src/TrombyApp/UI/Views/SettingsView.xaml.cs
@@ -1,0 +1,17 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace Tromby.UI.Views;
+
+/// <summary>
+/// Settings view for Tromby overlay.
+/// </summary>
+public sealed partial class SettingsView : Page
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SettingsView"/> class.
+    /// </summary>
+    public SettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Tromby/src/TrombyApp/UI/Views/ShellWindow.xaml
+++ b/Tromby/src/TrombyApp/UI/Views/ShellWindow.xaml
@@ -1,0 +1,42 @@
+<Window
+    x:Class="Tromby.UI.Views.ShellWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vm="using:Tromby.UI.ViewModels"
+    xmlns:components="using:Tromby.UI.Components"
+    Title="Tromby"
+    Width="480"
+    Height="640"
+    ExtendsContentIntoTitleBar="True">
+    <Window.DataContext>
+        <vm:ShellViewModel />
+    </Window.DataContext>
+    <Grid Padding="{StaticResource OverlayPadding}" Background="{StaticResource OverlayBackgroundBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+            <TextBlock Text="Tromby" Style="{StaticResource OverlayTitleText}" />
+            <TextBlock Text="·" Margin="0,0,4,0" Foreground="{StaticResource AccentBrush}" />
+            <TextBlock Text="{x:Bind ViewModel.ModeBadge, Mode=OneWay}" Foreground="{StaticResource AccentBrush}" />
+            <TextBlock Text="{x:Bind ViewModel.BudgetBadge, Mode=OneWay}" Margin="12,0,0,0" />
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="1">
+            <StackPanel Spacing="16">
+                <components:OnboardingCard
+                    Visibility="{x:Bind ViewModel.ShowOnboarding, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
+                    Dismissed="OnOnboardingDismissed" />
+                <ContentPresenter Content="{Binding MainContent}" />
+            </StackPanel>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="12">
+            <Button Content="Poser une question" Command="{x:Bind ViewModel.TriggerInteractionCommand}" />
+            <Button Content="Réglages" Command="{x:Bind ViewModel.OpenSettingsCommand}" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Tromby/src/TrombyApp/UI/Views/ShellWindow.xaml.cs
+++ b/Tromby/src/TrombyApp/UI/Views/ShellWindow.xaml.cs
@@ -1,0 +1,379 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Composition.SystemBackdrops;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using WinRT.Interop;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
+using Windows.Win32.UI.WindowsAndMessaging;
+using Tromby.Infra;
+using Tromby.UI.Components;
+using Tromby.UI.ViewModels;
+
+namespace Tromby.UI.Views;
+
+/// <summary>
+/// Primary overlay window using CompactOverlay presenter and handling global hotkeys.
+/// </summary>
+public sealed partial class ShellWindow : Window, IDisposable
+{
+    private readonly ShellViewModel _viewModel;
+    private readonly ILogger<ShellWindow> _logger;
+    private readonly MicaBackdrop _micaBackdrop = new();
+    private WindowId _windowId;
+    private AppWindow? _appWindow;
+    private bool _disposed;
+    private bool _isVisible = true;
+    private TaskbarBadgeService? _taskbarBadge;
+
+    private const int HOTKEY_TOGGLE_MODE = 0xB001;
+    private const int HOTKEY_TOGGLE_VISIBILITY = 0xB002;
+    private const int HOTKEY_DEMO_RESERVE = 0xB003;
+
+    [DllImport("user32.dll")]
+    private static extern bool RegisterHotKey(HWND hWnd, int id, HOT_KEY_MODIFIERS fsModifiers, uint vk);
+
+    [DllImport("user32.dll")]
+    private static extern bool UnregisterHotKey(HWND hWnd, int id);
+
+    /// <summary>
+    /// Creates the overlay shell window.
+    /// </summary>
+    public ShellViewModel ViewModel => _viewModel;
+
+    public ShellWindow(ShellViewModel viewModel, ILogger<ShellWindow> logger)
+    {
+        InitializeComponent();
+        _viewModel = viewModel;
+        _logger = logger;
+        DataContext = viewModel;
+        Activated += OnActivated;
+        Closed += OnClosed;
+        AppWindow.SetIcon("Assets/Icons/tromby.ico");
+        TryApplyBackdrop();
+        InitializeCompactOverlay();
+        WeakReferenceMessenger.Default.Register<SchedulerUpdatedMessage>(this, (_, __) =>
+        {
+            _viewModel.RefreshBadges();
+            UpdateTaskbarBadge();
+        });
+        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+    }
+
+    private void TryApplyBackdrop()
+    {
+        try
+        {
+            SystemBackdrop = _micaBackdrop;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Mica backdrop unavailable, falling back to default background.");
+        }
+    }
+
+    private void InitializeCompactOverlay()
+    {
+        try
+        {
+            var window = GetAppWindow();
+            if (window.Presenter.Kind != AppWindowPresenterKind.CompactOverlay)
+            {
+                window.SetPresenter(AppWindowPresenterKind.CompactOverlay);
+            }
+            window.IsShownInSwitchers = false;
+            if (window.Presenter is CompactOverlayPresenter presenter)
+            {
+                presenter.IsAlwaysOnTop = true;
+            }
+            EnsureTopMost();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to enable CompactOverlay presenter.");
+        }
+    }
+
+    private AppWindow GetAppWindow()
+    {
+        if (_appWindow is not null)
+        {
+            return _appWindow;
+        }
+
+        _windowId = Win32Interop.GetWindowIdFromWindow(this.GetWindowHandle());
+        _appWindow = AppWindow.GetFromWindowId(_windowId);
+        return _appWindow;
+    }
+
+    private void EnsureTopMost()
+    {
+        var hwnd = new HWND(this.GetWindowHandle());
+        PInvoke.SetWindowPos(hwnd, PInvoke.HWND_TOPMOST, 0, 0, 0, 0,
+            SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
+    }
+
+    private void OnActivated(object sender, WindowActivatedEventArgs e)
+    {
+        if (e.WindowActivationState == WindowActivationState.CodeActivated)
+        {
+            HwndExtensions.EnsureHook(this);
+            RegisterGlobalHotkeys();
+            EnsureTaskbarBadge();
+            UpdateTaskbarBadge();
+        }
+    }
+
+    private void OnClosed(object sender, WindowEventArgs e)
+    {
+        Dispose();
+    }
+
+    private void RegisterGlobalHotkeys()
+    {
+        var hwnd = new HWND(this.GetWindowHandle());
+        if (!RegisterHotKey(hwnd, HOTKEY_TOGGLE_MODE, HOT_KEY_MODIFIERS.MOD_ALT, (uint)VirtualKey.VK_Q))
+        {
+            _logger.LogWarning("Unable to register global hotkey Alt+Q.");
+        }
+        else
+        {
+            _logger.LogInformation("Global hotkey Alt+Q registered.");
+        }
+
+        if (!RegisterHotKey(hwnd, HOTKEY_TOGGLE_VISIBILITY, HOT_KEY_MODIFIERS.MOD_CONTROL, (uint)VirtualKey.VK_SPACE))
+        {
+            _logger.LogWarning("Unable to register global hotkey Ctrl+Space.");
+        }
+        else
+        {
+            _logger.LogInformation("Global hotkey Ctrl+Space registered.");
+        }
+
+        if (!RegisterHotKey(hwnd, HOTKEY_DEMO_RESERVE, HOT_KEY_MODIFIERS.MOD_ALT, (uint)VirtualKey.VK_D))
+        {
+            _logger.LogWarning("Unable to register global hotkey Alt+D.");
+        }
+        else
+        {
+            _logger.LogInformation("Global hotkey Alt+D registered.");
+        }
+
+        HwndExtensions.MessageReceived += OnWindowMessage;
+    }
+
+    private void OnWindowMessage(object? sender, WindowMessageEventArgs e)
+    {
+        if (e.MessageId != PInvoke.WM_HOTKEY)
+        {
+            return;
+        }
+
+        if (e.WParam == HOTKEY_TOGGLE_MODE)
+        {
+            _logger.LogInformation("Alt+Q pressed, toggling Qualité/Éco override.");
+            _viewModel.ToggleModeOverride();
+            UpdateTaskbarBadge();
+        }
+        else if (e.WParam == HOTKEY_TOGGLE_VISIBILITY)
+        {
+            _logger.LogInformation("Ctrl+Space pressed, toggling overlay visibility.");
+            ToggleVisibility();
+        }
+        else if (e.WParam == HOTKEY_DEMO_RESERVE)
+        {
+            _logger.LogInformation("Alt+D pressed, executing demo budget reservation.");
+            if (_viewModel.DemoReserveCommand.CanExecute(null))
+            {
+                _viewModel.DemoReserveCommand.Execute(null);
+                UpdateTaskbarBadge();
+            }
+        }
+    }
+
+    private void ToggleVisibility()
+    {
+        try
+        {
+            var window = GetAppWindow();
+            if (_isVisible)
+            {
+                window.Hide();
+                _isVisible = false;
+            }
+            else
+            {
+                window.Show();
+                _isVisible = true;
+                EnsureTopMost();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to toggle overlay visibility.");
+        }
+    }
+
+    private void EnsureTaskbarBadge()
+    {
+        if (_taskbarBadge is not null)
+        {
+            return;
+        }
+
+        try
+        {
+            var handle = this.GetWindowHandle();
+            if (handle != IntPtr.Zero)
+            {
+                _taskbarBadge = new TaskbarBadgeService(handle);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Taskbar badge service unavailable.");
+        }
+    }
+
+    private void UpdateTaskbarBadge()
+    {
+        if (_taskbarBadge is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _taskbarBadge.Update(_viewModel.CurrentQualityMode, _viewModel.BudgetPercent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to update taskbar badge state.");
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(ShellViewModel.ModeBadge) or nameof(ShellViewModel.BudgetBadge) or nameof(ShellViewModel.BudgetPercent) or nameof(ShellViewModel.CurrentQualityMode))
+        {
+            UpdateTaskbarBadge();
+        }
+    }
+
+    private void UnregisterGlobalHotkeys()
+    {
+        var hwnd = new HWND(this.GetWindowHandle());
+        UnregisterHotKey(hwnd, HOTKEY_TOGGLE_MODE);
+        UnregisterHotKey(hwnd, HOTKEY_TOGGLE_VISIBILITY);
+        UnregisterHotKey(hwnd, HOTKEY_DEMO_RESERVE);
+        HwndExtensions.MessageReceived -= OnWindowMessage;
+    }
+
+    private void OnOnboardingDismissed(object sender, OnboardingDismissedEventArgs e)
+    {
+        _viewModel.HandleOnboardingDismissal(e.DontShowAgain, e.ConsentRequested);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        UnregisterGlobalHotkeys();
+        _micaBackdrop.Dispose();
+        Activated -= OnActivated;
+        Closed -= OnClosed;
+        _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        _taskbarBadge?.Dispose();
+        _taskbarBadge = null;
+        WeakReferenceMessenger.Default.Unregister<SchedulerUpdatedMessage>(this);
+        GC.SuppressFinalize(this);
+    }
+}
+
+namespace Tromby.UI.ViewModels
+{
+    public partial class ShellViewModel
+    {
+        public string ModeBadge
+        {
+            get
+            {
+                var now = DateTime.Now;
+                var prefersQuality = !string.Equals(_scheduler.ActiveMode, "Éco", StringComparison.OrdinalIgnoreCase);
+                var qualityActive = _scheduler.ComputeEffectiveMode(prefersQuality, _scheduler.QualityStart, _scheduler.QualityEnd, now);
+                var label = qualityActive ? "Qualité" : "Éco";
+                if (string.Equals(_scheduler.ActiveMode, "Auto", StringComparison.OrdinalIgnoreCase))
+                {
+                    label += " (Auto)";
+                }
+
+                if (_scheduler.OverrideMsRemaining() > 0)
+                {
+                    label += " • Override";
+                }
+
+                return label;
+            }
+        }
+
+        public string BudgetBadge => BuildBudgetBadge();
+
+        public int BudgetPercent => _lastBudgetSnapshot?.DayPercent ?? 0;
+
+        public QualityMode CurrentQualityMode => _lastBudgetMode;
+
+        public void ToggleModeOverride()
+        {
+            var remaining = _scheduler.OverrideMsRemaining();
+            if (remaining > 0)
+            {
+                _scheduler.ManualOverride(0);
+                _logger.LogInformation("Manual override cleared.");
+            }
+            else
+            {
+                var minutes = _scheduler.OverrideMinutes > 0 ? _scheduler.OverrideMinutes : 5;
+                _scheduler.ManualOverride(minutes);
+                _logger.LogInformation("Manual override engaged for {Minutes} minutes.", minutes);
+            }
+
+            RefreshBadges();
+        }
+
+        public void HandleOnboardingDismissal(bool dontShowAgain, bool consentRequested)
+        {
+            ShowOnboarding = false;
+            if (dontShowAgain)
+            {
+                _logger.LogInformation("Onboarding dismissed with 'do not show again'.");
+            }
+
+            if (consentRequested)
+            {
+                var policyHash = _policyManager.CurrentPolicyHash;
+                _consentService.StoreConsentAsync(policyHash, _cts.Token).FireAndForget(_logger);
+                _logger.LogInformation("Consent stored for policy hash {Hash}.", policyHash);
+            }
+        }
+
+        public void RefreshBadges()
+        {
+            ActiveMode = _scheduler.ActiveMode;
+            UpdateBudgetBadge();
+            OnPropertyChanged(nameof(ModeBadge));
+            OnPropertyChanged(nameof(BudgetBadge));
+            OnPropertyChanged(nameof(BudgetPercent));
+            OnPropertyChanged(nameof(CurrentQualityMode));
+        }
+    }
+}

--- a/Tromby/src/TrombyApp/Voice/EdgeTtsService.cs
+++ b/Tromby/src/TrombyApp/Voice/EdgeTtsService.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Tromby.Voice;
+
+/// <summary>
+/// Uses Microsoft Edge APIs for neural TTS.
+/// </summary>
+public sealed class EdgeTtsService : IEdgeTtsService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<EdgeTtsService> _logger;
+    private readonly string _voice;
+    private readonly string _format;
+    private readonly string? _apiKey;
+    private readonly string _region;
+    private readonly string _endpoint;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EdgeTtsService"/> class.
+    /// </summary>
+    public EdgeTtsService(IHttpClientFactory httpClientFactory, IConfiguration configuration, ILogger<EdgeTtsService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+
+        var section = configuration.GetSection("voice:edge");
+        _voice = section["voice"] ?? "en-US-AriaNeural";
+        _format = section["outputFormat"] ?? "audio-16khz-128kbitrate-mono-mp3";
+        _apiKey = section["apiKey"];
+        _region = section["region"] ?? "westeurope";
+        _endpoint = section["endpoint"] ?? $"https://{_region}.tts.speech.microsoft.com/cognitiveservices/v1";
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream?> SpeakAsync(string text, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_apiKey))
+        {
+            _logger.LogWarning("Edge TTS API key missing. Skipping cloud synthesis.");
+            return null;
+        }
+
+        var client = _httpClientFactory.CreateClient(nameof(EdgeTtsService));
+        using var request = new HttpRequestMessage(HttpMethod.Post, _endpoint);
+        request.Headers.Add("Ocp-Apim-Subscription-Key", _apiKey);
+        request.Headers.Add("Ocp-Apim-Subscription-Region", _region);
+        request.Headers.UserAgent.Add(new ProductInfoHeaderValue("TrombyApp", "1.0"));
+        request.Headers.Add("X-Microsoft-OutputFormat", _format);
+
+        var ssml = BuildSsml(text);
+        request.Content = new StringContent(ssml, Encoding.UTF8, "application/ssml+xml");
+
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogWarning("Edge TTS failed with {Status}: {Message}", response.StatusCode, error);
+            return null;
+        }
+
+        var memory = new MemoryStream();
+        await response.Content.CopyToAsync(memory, cancellationToken).ConfigureAwait(false);
+        memory.Position = 0;
+        return memory;
+    }
+
+    private string BuildSsml(string text)
+    {
+        var escaped = SecurityElement.Escape(text) ?? string.Empty;
+        return $"<speak version='1.0' xml:lang='en-US'><voice name='{_voice}'>{escaped}</voice></speak>";
+    }
+}

--- a/Tromby/src/TrombyApp/Voice/IEdgeTtsService.cs
+++ b/Tromby/src/TrombyApp/Voice/IEdgeTtsService.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Voice;
+
+/// <summary>
+/// Provides speech synthesis via Microsoft Edge TTS service.
+/// </summary>
+public interface IEdgeTtsService
+{
+    /// <summary>
+    /// Synthesizes text into audio stream.
+    /// </summary>
+    Task<Stream?> SpeakAsync(string text, CancellationToken cancellationToken);
+}

--- a/Tromby/src/TrombyApp/Voice/ISapiFallbackService.cs
+++ b/Tromby/src/TrombyApp/Voice/ISapiFallbackService.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Voice;
+
+/// <summary>
+/// Provides legacy SAPI fallback when Edge TTS is unavailable.
+/// </summary>
+public interface ISapiFallbackService
+{
+    /// <summary>
+    /// Synthesizes text and returns audio stream.
+    /// </summary>
+    Task<Stream> SpeakAsync(string text, CancellationToken cancellationToken);
+}

--- a/Tromby/src/TrombyApp/Voice/IWhisperService.cs
+++ b/Tromby/src/TrombyApp/Voice/IWhisperService.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tromby.Voice;
+
+/// <summary>
+/// Handles speech-to-text capture via local Whisper models.
+/// </summary>
+public interface IWhisperService
+{
+    /// <summary>
+    /// Captures and transcribes user speech.
+    /// </summary>
+    Task<string> CaptureAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Transcribes an existing WAV file using the local Whisper runtime.
+    /// </summary>
+    /// <param name="filePath">Path to the WAV audio file.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<string> TranscribeAsync(string filePath, CancellationToken cancellationToken);
+}

--- a/Tromby/src/TrombyApp/Voice/SapiFallbackService.cs
+++ b/Tromby/src/TrombyApp/Voice/SapiFallbackService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Speech.Synthesis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Tromby.Voice;
+
+/// <summary>
+/// Uses Windows SAPI for fallback speech synthesis.
+/// </summary>
+public sealed class SapiFallbackService : ISapiFallbackService
+{
+    private readonly ILogger<SapiFallbackService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SapiFallbackService"/> class.
+    /// </summary>
+    public SapiFallbackService(ILogger<SapiFallbackService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<Stream> SpeakAsync(string text, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _logger.LogWarning("Using SAPI fallback for speech synthesis.");
+
+        var memoryStream = new MemoryStream();
+        using var synthesizer = new SpeechSynthesizer();
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnCompleted(object? sender, SpeakCompletedEventArgs args)
+        {
+            if (args.Cancelled)
+            {
+                tcs.TrySetCanceled();
+            }
+            else if (args.Error != null)
+            {
+                tcs.TrySetException(args.Error);
+            }
+            else
+            {
+                tcs.TrySetResult(null);
+            }
+        }
+
+        synthesizer.SpeakCompleted += OnCompleted;
+        synthesizer.SetOutputToWaveStream(memoryStream);
+
+        using var registration = cancellationToken.Register(() =>
+        {
+            synthesizer.SpeakAsyncCancelAll();
+            tcs.TrySetCanceled(cancellationToken);
+        });
+
+        synthesizer.SpeakAsync(text);
+        try
+        {
+            await tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            synthesizer.SpeakCompleted -= OnCompleted;
+        }
+
+        memoryStream.Position = 0;
+        return memoryStream;
+    }
+}

--- a/Tromby/src/TrombyApp/Voice/WhisperService.cs
+++ b/Tromby/src/TrombyApp/Voice/WhisperService.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Windows.Media.Capture;
+using Windows.Media.MediaProperties;
+using Windows.Storage;
+
+namespace Tromby.Voice;
+
+/// <summary>
+/// Local Whisper inference wrapper.
+/// </summary>
+public sealed class WhisperService : IWhisperService
+{
+    private readonly ILogger<WhisperService> _logger;
+    private readonly string? _executablePath;
+    private readonly string _modelPath;
+    private readonly string? _language;
+    private readonly string? _additionalArgs;
+    private readonly TimeSpan _captureDuration;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WhisperService"/> class.
+    /// </summary>
+    public WhisperService(IConfiguration configuration, ILogger<WhisperService> logger)
+    {
+        _logger = logger;
+        var section = configuration.GetSection("voice:whisper");
+        _executablePath = section["executable"];
+        _modelPath = section["model"] ?? "models/ggml-base.en.bin";
+        _language = section["language"];
+        _additionalArgs = section["extraArgs"];
+        _captureDuration = TimeSpan.FromSeconds(section.GetValue("captureSeconds", 6));
+    }
+
+    /// <inheritdoc />
+    public async Task<string> CaptureAsync(CancellationToken cancellationToken)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"tromby-whisper-{Guid.NewGuid():N}.wav");
+        try
+        {
+            await RecordMicrophoneAsync(tempFile, cancellationToken).ConfigureAwait(false);
+            return await TranscribeAsync(tempFile, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            TryDelete(tempFile);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<string> TranscribeAsync(string filePath, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_executablePath) || !File.Exists(_executablePath))
+        {
+            _logger.LogWarning("Whisper executable not configured or missing at {Path}.", _executablePath);
+            return string.Empty;
+        }
+
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException("Audio file not found.", filePath);
+        }
+
+        var arguments = BuildArguments(filePath);
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = _executablePath!,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start Whisper process.");
+        using var registration = cancellationToken.Register(() =>
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to cancel Whisper process cleanly.");
+            }
+        });
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        var output = await stdoutTask.ConfigureAwait(false);
+        var error = await stderrTask.ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Whisper exited with code {process.ExitCode}: {error}");
+        }
+
+        return ParseWhisperOutput(output);
+    }
+
+    private async Task RecordMicrophoneAsync(string destinationPath, CancellationToken cancellationToken)
+    {
+        using var capture = new MediaCapture();
+        var settings = new MediaCaptureInitializationSettings
+        {
+            StreamingCaptureMode = StreamingCaptureMode.Audio
+        };
+
+        await capture.InitializeAsync(settings).AsTask(cancellationToken);
+
+        var tempFile = await ApplicationData.Current.TemporaryFolder.CreateFileAsync(
+            $"tromby-capture-{Guid.NewGuid():N}.wav",
+            CreationCollisionOption.ReplaceExisting).AsTask(cancellationToken);
+
+        var profile = MediaEncodingProfile.CreateWav(AudioEncodingQuality.Auto);
+        await capture.StartRecordToStorageFileAsync(profile, tempFile).AsTask(cancellationToken);
+
+        try
+        {
+            await Task.Delay(_captureDuration, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await capture.StopRecordAsync().AsTask();
+        }
+
+        using var sourceStream = await tempFile.OpenReadAsync().AsTask(cancellationToken);
+        await using var destination = File.Create(destinationPath);
+        await sourceStream.AsStreamForRead().CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
+        await tempFile.DeleteAsync().AsTask();
+    }
+
+    private string BuildArguments(string filePath)
+    {
+        var builder = new StringBuilder();
+        builder.Append("--model \"").Append(_modelPath).Append("\"");
+        builder.Append(' ').Append("--file \"").Append(filePath).Append("\"");
+        builder.Append(" --output_format json");
+        if (!string.IsNullOrWhiteSpace(_language))
+        {
+            builder.Append(" --language ").Append(_language);
+        }
+
+        if (!string.IsNullOrWhiteSpace(_additionalArgs))
+        {
+            builder.Append(' ').Append(_additionalArgs);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string ParseWhisperOutput(string output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(output);
+            if (document.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                var builder = new StringBuilder();
+                foreach (var segment in document.RootElement.EnumerateArray())
+                {
+                    if (segment.TryGetProperty("text", out var textElement))
+                    {
+                        builder.Append(textElement.GetString());
+                    }
+                }
+
+                return builder.ToString().Trim();
+            }
+
+            if (document.RootElement.TryGetProperty("text", out var text))
+            {
+                return text.GetString() ?? string.Empty;
+            }
+        }
+        catch (JsonException)
+        {
+            // Fallback to raw output below.
+        }
+
+        return output.Trim();
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // ignore cleanup failures
+        }
+    }
+}

--- a/Tromby/tests/Tromby.Tests/OrchestratorTests.cs
+++ b/Tromby/tests/Tromby.Tests/OrchestratorTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tromby.Core.Scheduling;
+using Tromby.Infra.Metrics;
+using Tromby.Tools.Sandbox;
+using Tromby.Infra;
+using Xunit;
+
+namespace Tromby.Tests;
+
+public class OrchestratorTests
+{
+    [Fact]
+    public void Scheduler_OverMidnight_WindowDetection_Works()
+    {
+        var scheduler = CreateScheduler();
+        var start = new TimeSpan(23, 0, 0);
+        var end = new TimeSpan(6, 0, 0);
+
+        Assert.True(scheduler.IsInQualityWindow(start, end, new DateTime(2025, 1, 1, 23, 30, 0)));
+        Assert.True(scheduler.IsInQualityWindow(start, end, new DateTime(2025, 1, 2, 5, 59, 0)));
+        Assert.False(scheduler.IsInQualityWindow(start, end, new DateTime(2025, 1, 2, 12, 0, 0)));
+    }
+
+    [Fact]
+    public async Task PowerShellSandbox_Enforces_Whitelist_And_Confirmation()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["policy:actions:whitelist:0"] = "Get-ChildItem",
+                ["policy:actions:whitelist:1"] = "Get-Process",
+                ["policy:actions:requireConfirm:0"] = "Set-Content",
+                ["policy:limits:sandboxTimeoutSeconds"] = "5",
+                ["policy:limits:ioBytesPerMinute"] = "2048"
+            })
+            .Build();
+
+        var sandbox = new PowerShellSandbox(new TestLogger<PowerShellSandbox>(), configuration);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sandbox.ExecuteAsync("Remove-Item", true, CancellationToken.None));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sandbox.ExecuteAsync("Set-Content", false, CancellationToken.None));
+
+        if (OperatingSystem.IsWindows())
+        {
+            var output = await sandbox.ExecuteAsync("Get-ChildItem", true, CancellationToken.None);
+            Assert.NotNull(output);
+        }
+    }
+
+    [Fact]
+    public void BudgetService_SoftAndHardCaps_Work()
+    {
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp,
+                "{""Mode"":{""Qualite"":{""PerDay"":{""Tokens"":100,""Cost"":1.0},""PerConversation"":{""Tokens"":50,""Cost"":0.5},""SoftCapPercent"":80},""Eco"":{""PerDay"":{""Tokens"":50,""Cost"":0.5},""PerConversation"":{""Tokens"":25,""Cost"":0.25},""SoftCapPercent"":75}}}");
+
+            var service = new BudgetService(tmp);
+            var conversation = service.BeginConversation();
+
+            Assert.True(service.TryConsume(QualityMode.Qualite, conversation, 60, 0.2m, out var snap1, out var soft1));
+            Assert.Equal(60, snap1.DayTokensUsed);
+            Assert.False(soft1);
+
+            Assert.True(service.TryConsume(QualityMode.Qualite, conversation, 20, 0.2m, out var snap2, out var soft2));
+            Assert.True(soft2);
+            Assert.Equal(80, snap2.DayPercent);
+
+            Assert.False(service.TryConsume(QualityMode.Qualite, conversation, 30, 0.8m, out _, out _));
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+    }
+
+    private static AdaptiveScheduler CreateScheduler()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["scheduler:qualityStart"] = "23:00:00",
+                ["scheduler:qualityEnd"] = "06:00:00",
+                ["scheduler:overrideMinutes"] = "30",
+                ["budgets:defaultMode"] = "Qualite"
+            })
+            .Build();
+
+        return new AdaptiveScheduler(configuration, new NoopMetricsCollector(), new TestLogger<AdaptiveScheduler>());
+    }
+
+    private sealed class NoopMetricsCollector : IMetricsCollector
+    {
+        public void TrackCompletion(string providerName) { }
+        public void TrackModeSwitch(string mode) { }
+        public void TrackBudgetUsed(string mode, int tokens, decimal cost, int percent, bool softCap, bool hardCap) { }
+        public void TrackThrottle(string scope, string reason) { }
+        public void TrackToolInvocation(string toolName) { }
+        public void TrackToolCancelled(string toolName) { }
+    }
+
+    private sealed class TestLogger<T> : ILogger<T>, IDisposable
+    {
+        public IDisposable BeginScope<TState>(TState state) => this;
+
+        public void Dispose()
+        {
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
+}

--- a/Tromby/tests/Tromby.Tests/Tromby.Tests.csproj
+++ b/Tromby/tests/Tromby.Tests/Tromby.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TrombyApp\TrombyApp.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- color-code the taskbar progress indicator based on budget thresholds
- add a demo budget reservation command with metrics tracking in the shell view model
- register an Alt+D global hotkey that triggers the demo reserve and refreshes taskbar badges

## Testing
- `dotnet test Tromby.sln` *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceacdd03d4832d9ba32273ce65b95a